### PR TITLE
[COLAB-2109] Allow admins to create propsoals in closed phases

### DIFF
--- a/view/src/main/webapp/WEB-INF/jsp/proposals/contestProposals.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/proposals/contestProposals.jspx
@@ -50,7 +50,8 @@
                     </c:choose>
                 </h2>
 
-                <c:if test="${proposalsPermissions.isCreationAllowedByPhase }">
+                <c:set var="isProposalCreationAllowed" value="${proposalsPermissions.isCreationAllowedByPhase || _isAdmin}" />
+                <c:if test="${isProposalCreationAllowed}">
                     <c:set var="createProposalURL" value="${contest.newProposalLinkUrl}"/>
                 </c:if>
                 <c:choose>
@@ -76,7 +77,7 @@
                 </c:choose>
 
                 <div class="right">
-                    <c:if test="${proposalsPermissions.isCreationAllowedByPhase }">
+                    <c:if test="${isProposalCreationAllowed}">
                         <a class="c-Button__primary large" rel="nofollow" href="${proposalsPermissions.canCreate ? createProposalURL : '#'}"
                            onclick="if(!handleOnClickAtSupportBtn()) return false;">
                             ${contestType.creationPrompt}


### PR DESCRIPTION
Creating a proposal was already possible as an admin. I just had to activate the button.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/16)
<!-- Reviewable:end -->
