### PR TITLE
[COLAB-1245] Add links to sponsor logos

### DIFF
--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
@@ -302,7 +302,7 @@ public class Contest extends AbstractContest implements Serializable {
 
 
     public boolean getSponsorLinkAvailable() {
-        return !this.getSponsorLink().equals("");
+        return !this.getSponsorLink().isEmpty();
     }
 
 

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
@@ -1,5 +1,7 @@
 package org.xcolab.client.contest.pojo;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.xcolab.client.admin.ContestTypeClient;
 import org.xcolab.client.admin.attributes.configuration.ConfigurationAttributeKey;
 import org.xcolab.client.admin.attributes.platform.PlatformAttributeKey;
@@ -302,7 +304,7 @@ public class Contest extends AbstractContest implements Serializable {
 
 
     public boolean getSponsorLinkAvailable() {
-        return !this.getSponsorLink().isEmpty();
+        return !StringUtils.isEmpty(this.getSponsorLink());
     }
 
 

--- a/sql/deployments/deployment-2017-08-31__ClimateCoaLab.sql
+++ b/sql/deployments/deployment-2017-08-31__ClimateCoaLab.sql
@@ -1,2 +1,2 @@
 -- COLAB-1245
-ALTER TABLE xcolab_Contest MODIFY sponsorLink VARCHAR(2000);
+ALTER TABLE xcolab_Contest MODIFY sponsorLink VARCHAR(500);

--- a/sql/deployments/deployment-2017-08-31__ClimateCoaLab.sql
+++ b/sql/deployments/deployment-2017-08-31__ClimateCoaLab.sql
@@ -1,0 +1,2 @@
+-- COLAB-1245
+ALTER TABLE xcolab_Contest MODIFY sponsorLink VARCHAR(2000);

--- a/sql/starter/xcolab-schema.sql
+++ b/sql/starter/xcolab-schema.sql
@@ -1089,7 +1089,7 @@ CREATE TABLE `xcolab_Contest` (
   `sponsorLogoId` bigint(20) DEFAULT NULL,
   `defaultProposalLogoId` BIGINT(20) NULL DEFAULT NULL,
   `sponsorText` varchar(500) DEFAULT NULL,
-  `sponsorLink` varchar(75) DEFAULT NULL,
+  `sponsorLink` varchar(2000) DEFAULT NULL,
   `flag` int(11) DEFAULT NULL,
   `flagText` varchar(256) DEFAULT NULL,
   `flagTooltip` varchar(512) DEFAULT NULL,

--- a/sql/starter/xcolab-schema.sql
+++ b/sql/starter/xcolab-schema.sql
@@ -1089,7 +1089,7 @@ CREATE TABLE `xcolab_Contest` (
   `sponsorLogoId` bigint(20) DEFAULT NULL,
   `defaultProposalLogoId` BIGINT(20) NULL DEFAULT NULL,
   `sponsorText` varchar(500) DEFAULT NULL,
-  `sponsorLink` varchar(2000) DEFAULT NULL,
+  `sponsorLink` varchar(500) DEFAULT NULL,
   `flag` int(11) DEFAULT NULL,
   `flagText` varchar(256) DEFAULT NULL,
   `flagTooltip` varchar(512) DEFAULT NULL,

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/beans/ContestBatchBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/beans/ContestBatchBean.java
@@ -28,6 +28,8 @@ public class ContestBatchBean {
 
     private Long sponsorLogoId;
 
+    private String sponsorLink;
+
     private List<ContestCSVBean> contestCSVs;
 
     public List<ContestCSVBean> getContestCSVs() {
@@ -44,6 +46,14 @@ public class ContestBatchBean {
 
     public void setSponsorLogoId(Long sponsorLogoId) {
         this.sponsorLogoId = sponsorLogoId;
+    }
+
+    public String getSponsorLink() {
+        return sponsorLink;
+    }
+
+    public void setSponsorLink(String sponsorLink) {
+        this.sponsorLink = sponsorLink;
     }
 
 

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/beans/ContestDescriptionBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/beans/ContestDescriptionBean.java
@@ -29,7 +29,7 @@ public class ContestDescriptionBean implements Serializable {
     private Long ContestPK;
     private Long contestLogoId;
     private Long sponsorLogoId;
-    @Length(max = 2000, message = "The sponsor link URL must not be longer than 2000 characters.")
+    @Length(max = 500, message = "The sponsor link URL must not be longer than 500 characters.")
     private String sponsorLink;
     private Long defaultproposallogoid;
 

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/beans/ContestDescriptionBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/beans/ContestDescriptionBean.java
@@ -29,6 +29,8 @@ public class ContestDescriptionBean implements Serializable {
     private Long ContestPK;
     private Long contestLogoId;
     private Long sponsorLogoId;
+    @Length(max = 2000, message = "The sponsor link URL must not be longer than 2000 characters.")
+    private String sponsorLink;
     private Long defaultproposallogoid;
 
     @Length(min = 3, max = 150, message = "The contest question must be at least 3 characters and"
@@ -70,6 +72,7 @@ public class ContestDescriptionBean implements Serializable {
             scheduleTemplateId = contest.getContestScheduleId();
             contestLogoId = contest.getContestLogoId();
             sponsorLogoId = contest.getSponsorLogoId();
+            sponsorLink= contest.getSponsorLink();
             defaultproposallogoid = contest.getDefaultProposalLogoId();
             shouldUpdateContestUrlName = !contest.getContestActive();
             isSharedContest = contest.getIsSharedContest();
@@ -107,6 +110,7 @@ public class ContestDescriptionBean implements Serializable {
         contest.setPlanTemplateId(planTemplateId);
         contest.setContestLogoId(contestLogoId);
         contest.setSponsorLogoId(sponsorLogoId);
+        contest.setSponsorLink(sponsorLink);
         contest.setDefaultProposalLogoId(defaultproposallogoid);
         contest.setIsSharedContest(isSharedContest);
         ContestClientUtil.updateContest(contest);
@@ -155,6 +159,14 @@ public class ContestDescriptionBean implements Serializable {
 
     public void setSponsorLogoId(Long sponsorLogoId) {
         this.sponsorLogoId = sponsorLogoId;
+    }
+
+    public String getSponsorLink() {
+        return sponsorLink;
+    }
+
+    public void setSponsorLink(String sponsorLink) {
+        this.sponsorLink= sponsorLink;
     }
 
     public String getContestName() {

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/beans/ContestDescriptionBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/beans/ContestDescriptionBean.java
@@ -72,7 +72,7 @@ public class ContestDescriptionBean implements Serializable {
             scheduleTemplateId = contest.getContestScheduleId();
             contestLogoId = contest.getContestLogoId();
             sponsorLogoId = contest.getSponsorLogoId();
-            sponsorLink= contest.getSponsorLink();
+            sponsorLink = contest.getSponsorLink();
             defaultproposallogoid = contest.getDefaultProposalLogoId();
             shouldUpdateContestUrlName = !contest.getContestActive();
             isSharedContest = contest.getIsSharedContest();

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/BatchCreationController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/BatchCreationController.java
@@ -146,6 +146,8 @@ public class BatchCreationController {
                                 : (contestBatchBean.getContestLogoId())),
                         ((contestBatchBean.getSponsorLogoId() == null) ? (0L)
                                 : (contestBatchBean.getSponsorLogoId())),
+                        ((contestBatchBean.getSponsorLink() == null) ? ("")
+                                : (contestBatchBean.getSponsorLink())),
                         contestBatchBean.getPlanTemplateId(),
                         contestBatchBean.getScheduleTemplateId(),
                         contestBatchBean.getContestTier(),
@@ -227,6 +229,7 @@ public class BatchCreationController {
             String contestQuestion,
             Long contestLogoId,
             Long sponsorLogoId,
+            String sponsorLink,
             Long planTemplateId,
             Long contestScheduleId,
             Long contestTierId,
@@ -238,6 +241,7 @@ public class BatchCreationController {
         contest.setContestName(contestQuestion);
         contest.setContestLogoId(contestLogoId);
         contest.setSponsorLogoId(sponsorLogoId);
+        contest.setSponsorLink(sponsorLink);
         contest.setContestYear((long) DateTime.now().getYear());
         contest.setContestPrivate(true);
         contest.setShow_in_tile_view(true);

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/batch/uploadContestCSV.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/batch/uploadContestCSV.jspx
@@ -75,7 +75,7 @@
             </div>
             <div class="addpropbox">
                 <label>
-                    <strong>Organization/company logo</strong>
+                    <strong>Sponsor logo</strong>
                 </label>
 
                 <div class="addprophelp">If available, it is preferred to use a version of the logo that is horizontal
@@ -85,6 +85,17 @@
                 <form:hidden path="sponsorLogoId" id="logoImageId"/>
                 <collab:imageUpload uniqueName="logoImage" imageIdInput="logoImageId" compactView="true"
                                     defaultImage="CONTEST" defaultImageId="${contestWrapper.sponsorLogoId}" />
+            </div>
+            <div class="addpropbox">
+                <label>
+                    <strong>Sponsor link</strong>
+                </label>
+
+                <div class="addprophelp">
+                    An optional link that it opened when a user clicks on the sponsor logo.
+                </div>
+
+                <form:input path="sponsorLink" id="sponsorLink"/>
             </div>
             <div class="addpropbox blue">
                 <label>

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/details/descriptionTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/details/descriptionTab.jspx
@@ -111,7 +111,7 @@
 
             <div class="addpropbox blue">
                 <label>
-                    <strong>Organization/company logo</strong>
+                    <strong>Sponsor logo</strong>
                 </label>
 
                 <div class="addprophelp">If available, it is preferred to use a version of the logo that is horizontal
@@ -121,6 +121,18 @@
                 <form:hidden path="sponsorLogoId" id="logoImageId"/>
                 <collab:imageUpload uniqueName="logoImage" imageIdInput="logoImageId" compactView="true"
                                     defaultImage="CONTEST" defaultImageId="${contestWrapper.sponsorLogoId}" />
+            </div>
+
+            <div class="addpropbox">
+                <label>
+                    <strong>Sponsor link</strong>
+                </label>
+
+                <div class="addprophelp">
+                    An optional link that it opened when a user clicks on the sponsor logo.
+                </div>
+
+                <form:input path="sponsorLink" id="sponsorLink"/>
             </div>
 
             <div class="addpropbox blue">

--- a/view/src/main/webapp/WEB-INF/jsp/proposals/contestProposals/header_contest_details.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/proposals/contestProposals/header_contest_details.jspx
@@ -14,7 +14,7 @@
                     <c:if test="${contest.sponsorLogoId > 0}">
                         <c:choose>
                             <c:when test="${contest.sponsorLinkAvailable}">
-                                <a href="//${contest.sponsorLink}">
+                                <a href="${contest.sponsorLink}" target="_blank">
                                     <img src="${contest.sponsorLogoPath}"
                                             alt="Sponsor Logo"
                                             class="p-ContestProposals__header__sponsorLogo"/>


### PR DESCRIPTION
This PR implements linkable sponsor logos. On contest creation/edit, a sponsor link can be set. If a sponsor link is set, clicking on the sponsor logo of a contest will open the sponsor link URL in a new tab/window.

The sponsorLink field was already present in the database schema. I've adapted the VARCHAR length from 75 to 2000 to allow for longer URLs.

For the sake of consistency, I've renamed the "Organization/company logo" property field in the edit contest view to "Sponsor Logo".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/21)
<!-- Reviewable:end -->
