### PR TITLE
[COLAB-2192] Add CSRF tokens to all forms/requests

### DIFF
--- a/view/pom.xml
+++ b/view/pom.xml
@@ -84,6 +84,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
 
         <!-- url rewriting-->
         <dependency>

--- a/view/src/main/java/org/xcolab/view/config/spring/beans/WebSecurityConfig.java
+++ b/view/src/main/java/org/xcolab/view/config/spring/beans/WebSecurityConfig.java
@@ -112,8 +112,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                     .permitAll()
                     .logoutSuccessHandler(new LogoutSuccessHandler())
                     .and()
-                .csrf()
-                    .disable()
                 .headers()
                     .defaultsDisabled()
                     .addHeaderWriter(

--- a/view/src/main/resources/static/js/proposals/discussionComments.js
+++ b/view/src/main/resources/static/js/proposals/discussionComments.js
@@ -27,6 +27,7 @@ function editComment(messageId, url){
     }
     var formContent = '<form method="post" action="' + url + '">';
     formContent += '<textarea class="rte-editorPlaceholder" id="text_' + messageId + '" name="comment" style="width: 100%; height: 150px;"></textarea>';
+    formContent += '<input name="_csrf" type="hidden" value="' + $('#_csrf').val() + '"/>';
     formContent += '<input name="messageId" type="hidden" value="' + messageId + '"/>';
     formContent += '<a class="c-Button__primary" style="margin-left: 320px; margin-top: 10px;" onclick="disableDirtyCheck(); $(this).parents(\'form:first\').submit();" type="submit" href="javascript:;">Save</a>';
     formContent += '</form>';

--- a/view/src/main/webapp/WEB-INF/jsp/contenteditor/editor.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contenteditor/editor.jspx
@@ -12,6 +12,8 @@
         <xcolab:requireLibrary name="CKEditor" />
         <xcolab:script src="${_libJsFolder}/jquery.loadmask.spin.js" />
 
+        <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
 
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqtree/1.3.6/jqtree.min.css"><!-- --></link>
         <!-- link rel="stylesheet" href="${pageContext.request.contextPath}/js/ckeditor/contents.css"></link -->
@@ -535,6 +537,7 @@
                 </div>
             </div>
             <form target="_blank" action="${previewArticleURL}" method="post" id="previewArticleForm">
+                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                 <input type="hidden" id="htmlContent" name="content" />
             </form>
         </div>

--- a/view/src/main/webapp/WEB-INF/jsp/contenteditor/resourcePagesEditor.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contenteditor/resourcePagesEditor.jspx
@@ -11,6 +11,8 @@
         <xcolab:requireLibrary name="CKEditor" />
         <xcolab:script src="${_libJsFolder}/jquery.loadmask.spin.js" />
 
+        <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqtree/1.3.6/jqtree.min.css"><!-- --></link>
         <!-- link rel="stylesheet" href="${pageContext.request.contextPath}/js/ckeditor/contents.css"></link -->
         <style>
@@ -365,6 +367,7 @@
                 </div>
             </div>
             <form target="_blank" action="${previewArticleURL}" method="post" id="previewArticleForm">
+                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                 <input type="hidden" id="htmlContent" name="content" />
             </form>
         </div>

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/details/ontologyTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/details/ontologyTab.jspx
@@ -7,6 +7,7 @@
 
 	<!--@elvariable id="contestWrapper" type="org.xcolab.client.contest.pojo.Contest"-->
     <!--@elvariable id="ontologySpaces" type="java.util.List<org.xcolab.client.contest.pojo.ontology.OntologySpace>"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
 	<jsp:directive.include file="../init.jspx" />
 	<jsp:directive.include file="./header.jspx"/>
@@ -19,6 +20,7 @@
 
 		<form action="${updateContestOntologyURL }" id="editForm" method="post">
 			<input type="hidden" name="selectedOntologyTerms" id="selectedOntologyTerms"/>
+            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 		</form>
 
 		<h2>Contest ontology</h2>

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/action.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/action.jspx
@@ -2,6 +2,7 @@
 		  xmlns:xcolab="urn:jsptagdir:/WEB-INF/tags" version="2.0">
 
 	<!--@elvariable id="elementId" type="java.lang.Long"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
 	<portlet:actionURL var="createNewElementFormURL">
 		<portlet:param name="tab" value="${param.tab}" />
@@ -26,10 +27,12 @@
 
 
 	<form action="${deleteElementFormURL}" id="deleteElementForm" method="post" style="visibility: hidden;" >
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 		<!-- -->
 	</form>
 
 	<form action="${createNewElementFormURL}" id="createNewElementForm" method="post" style="visibility: hidden;" >
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 		<!-- -->
 	</form>
 

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/adminTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/adminTab.jspx
@@ -12,6 +12,7 @@
     <!--@elvariable id="ontologyTermsWhere" type="java.util.List<org.xcolab.portlets.contestmanagement.wrappers.OntologyTermWrapper>"-->
     <!--@elvariable id="section" type="java.lang.Integer"-->
     <!--@elvariable id="level" type="java.lang.Integer"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
     <jsp:directive.include file="../init.jspx"/>
     <jsp:directive.include file="./header.jspx"/>
@@ -49,6 +50,7 @@
         <div class="addpropbox">
             <h2>Server administration</h2>
             <form action="/admin/caching/clear" method="post">
+                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                 <button type="submit" class="c-Button__primary">Clear cache</button>
             </form>
         </div>
@@ -82,6 +84,7 @@
 
                 <form action="/admin/contest/manager/tab/ADMIN/notificationMessageDelete"
                       id="deleteNotificationForm" method="post" style="visibility: hidden;" >
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                     <input type="hidden" id = "notificationId" name="notificationId"/>
                 </form>
 
@@ -151,6 +154,7 @@
         <div class="addpropbox">
             <h2>Activities CSV export</h2>
             <form action="/admin/contest/manager/tab/ADMIN/exportActivities" method="post">
+                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                 <button type="submit" class="c-Button__primary">Export activities</button>
             </form>
         </div>
@@ -158,6 +162,7 @@
         <div class="addpropbox">
             <h2>Batch register members</h2>
             <form action="/admin/contest/manager/tab/ADMIN/batchRegister" method="post">
+                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                 <div class="c-Alert__info__message" for="batchRegisterMembersList">
                     Each member will receive an email with a link that allows them to sign in.
                     Enter one member per line in the following format:<br/>

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/collectionCardTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/collectionCardTab.jspx
@@ -12,6 +12,7 @@
     <!--@elvariable id="ontologyTermsWhere" type="java.util.List<org.xcolab.portlets.contestmanagement.wrappers.OntologyTermWrapper>"-->
     <!--@elvariable id="section" type="java.lang.Integer"-->
     <!--@elvariable id="level" type="java.lang.Integer"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
     <jsp:directive.include file="../init.jspx"/>
     <jsp:directive.include file="./header.jspx"/>
@@ -56,6 +57,7 @@
         <c:set var="deleteContestCollectionCardURL" value="/admin/contest/manager/tab/COLLECTION_CARDS/delete" />
 
         <form action="${deleteContestCollectionCardURL }" id="deleteCollectionCardForm" method="post" style="visibility: hidden;">
+            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
             <input id="collectionCardId" name="collectionCardId"  type="hidden" value=""/>
         </form>
 

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/emailTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/emailTab.jspx
@@ -7,6 +7,7 @@
     <!--@elvariable id="templateType" type="java.lang.String"-->
     <!--@elvariable id="emailTemplateWrapper" type="org.xcolab.portlets.contestmanagement.wrappers.EmailTemplateWrapper"-->
     <!--@elvariable id="templateSelectionItems" type="java.util.List<org.xcolab.portlets.contestmanagement.entities.LabelStringValue>"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
     <jsp:directive.include file="../init.jspx"/>
     <jsp:directive.include file="./header.jspx"/>
@@ -17,11 +18,12 @@
     <c:set var="deleteEmailTemplateUrl" value="/admin/contest/manager/tab/EMAIL_TEMPLATES/delete/${emailTemplateWrapper.type}" />
 
     <form action="${deleteEmailTemplateUrl}" id="deleteTemplateForm" method="post" style="visibility: hidden;">
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
         <!-- -->
     </form>
 
     <form action="${createEmailTemplateUrl}" id="createTemplateForm" method="post" style="visibility: hidden;">
-
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
         <!-- -->
     </form>
 

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/flaggingTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/flaggingTab.jspx
@@ -11,6 +11,7 @@
     <!--@elvariable id="selectionItems" type="java.util.List<org.xcolab.portlets.contestmanagement.entities.LabelValue>"-->
 
     <!--@elvariable id="reports" type="java.util.List<org.xcolab.portlets.contestmanagement.wrappers.FlaggingReportWrapper>"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
     <jsp:directive.include file="../init.jspx"/>
     <jsp:directive.include file="./header.jspx"/>
@@ -22,11 +23,12 @@
 
 
     <form action="${deleteReportTargetUrl}" id="deleteReportTargetForm" method="post" style="visibility: hidden;">
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
         <!-- -->
     </form>
 
     <form action="${createReportTargetUrl}" id="createReportTargetForm" method="post" style="visibility: hidden;">
-
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
         <!-- -->
     </form>
 

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
@@ -12,6 +12,7 @@
     <!--@elvariable id="elementSelectIdWrapper" type="org.xcolab.view.pages.contestmanagement.wrappers.ElementSelectIdWrapper"-->
     <!--@elvariable id="contestPhaseTypesSelectionItems" type="java.util.List<org.xcolab.util.html.LabelValue>"-->
     <!--@elvariable id="contestPhaseAutopromoteSelectionItems" type="java.util.List<org.xcolab.util.html.LabelValue>"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
     <jsp:directive.include file="../init.jspx"/>
     <jsp:directive.include file="./header.jspx"/>
@@ -24,10 +25,12 @@
 
     <form action="${updateContestScheduleUrl}?elementId=${contestScheduleBean.scheduleId}"
           id="deleteScheduleForm" method="post" style="visibility: hidden;">
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
         <input type="hidden" name="action" value="DELETE"/>
     </form>
 
     <form action="${updateContestScheduleUrl}" id="createScheduleForm" method="post" style="visibility: hidden;">
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
         <input type="hidden" name="action" value="CREATE"/>
     </form>
 

--- a/view/src/main/webapp/WEB-INF/jsp/discussion/category_add.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/discussion/category_add.jspx
@@ -3,6 +3,9 @@
           xmlns:c="http://java.sun.com/jsp/jstl/core"
           version="2.0" xmlns:spring="http://www.springframework.org/tags">
     <jsp:directive.page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"/>
+
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
     <xcolab:layout>
         <jsp:directive.include file="init.jspx"/>
      <div id="content">
@@ -20,6 +23,7 @@
             <div class="c-Comment__new">
                 <c:set var="addCategoryUrl" value="/discussion/category/createCategory" />
                 <form id="addThreadForm" action="${addCategoryUrl }" method="post">
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                     <div>
                         <label class="portlet-form-label"><spring:message code="discussion.categoryadd.form.title"/><br />
                             <input class="portlet-form-input-field input_long" name="title" maxlength="255" style="width:660px;" type="text" value="" />

--- a/view/src/main/webapp/WEB-INF/jsp/discussion/thread_add.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/discussion/thread_add.jspx
@@ -6,6 +6,7 @@
 <xcolab:layout>
     <jsp:directive.include file="init.jspx"/>
     <!--@elvariable id="categories" type="java.util.List<org.xcolab.client.comment.pojo.Category>"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
     <div id="content">
         <div id="bread" class="pro">
@@ -21,6 +22,7 @@
             <div class="c-Comment__new">
                 <c:set var="addThreadUrl" value="/discussion/thread/create" />
                 <form id="addThreadForm" action="${addThreadUrl }" method="post">
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                     <div>
                         <label class="portlet-form-label"><spring:message code="discussion.threadadd.table.category" /><br />
                             <select class="portlet-form-field" name="categoryId">

--- a/view/src/main/webapp/WEB-INF/jsp/error.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/error.jspx
@@ -28,6 +28,7 @@
             <!--@elvariable id="message" type="java.lang.String"-->
             <!--@elvariable id="path" type="java.lang.String"-->
             <!--@elvariable id="trace" type="java.lang.String"-->
+            <!--@elvariable id="ontologySpaces" type="java.util.List<org.xcolab.client.contest.pojo.ontology.OntologySpace>"-->
 
             <c:set var="trace" value="${fn:escapeXml(trace)}"/>
             <c:choose>
@@ -44,6 +45,7 @@
                 <c:otherwise>
                     <div class="login_popup_box" style="margin: 0 8px 0 0;padding: 0;">
                         <form id="signInForm_form" method="post" action="/reportError">
+                            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                             <input name="url" type="hidden" />
                             <input id="stackTrackeInput" name="stackTrace" type="hidden" value="${trace}"/>
                             <input name="referer" type="hidden" value="${header.get('referer')}"/>

--- a/view/src/main/webapp/WEB-INF/jsp/error.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/error.jspx
@@ -28,7 +28,7 @@
             <!--@elvariable id="message" type="java.lang.String"-->
             <!--@elvariable id="path" type="java.lang.String"-->
             <!--@elvariable id="trace" type="java.lang.String"-->
-            <!--@elvariable id="ontologySpaces" type="java.util.List<org.xcolab.client.contest.pojo.ontology.OntologySpace>"-->
+            <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
             <c:set var="trace" value="${fn:escapeXml(trace)}"/>
             <c:choose>

--- a/view/src/main/webapp/WEB-INF/jsp/loginregister/SSO/registerOrLogin.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/loginregister/SSO/registerOrLogin.jspx
@@ -9,6 +9,8 @@
 
     <!--@elvariable id="__errorMessage" type="org.xcolab.view.util.entity.flash.ErrorMessage"-->
 
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
     <h1 style="padding-left: 20px;">
     Welcome to the ${_colabName}!</h1>
     <br /><br />
@@ -28,6 +30,7 @@
                 </c:if>
                 <div class="c-Header__login__box" style="margin: 15px auto 0 auto;">
                     <form id="signInFormPopup" method="post" action="/sso/registerOrLogin">
+                        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                         <input name="login" type="text" class="c-Header__login__username" placeholder="username or email address" />
                         <input name="password" type="password" class="c-Header__login__password" placeholder="password" />
                         <span><em>

--- a/view/src/main/webapp/WEB-INF/jsp/loginregister/loginWithToken.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/loginregister/loginWithToken.jspx
@@ -3,6 +3,8 @@
           xmlns:jsp="http://java.sun.com/JSP/Page" version="2.0">
 <jsp:directive.page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"/>
 
+<!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
 <layout:layout title="Login link">
     <h2>Login with unique link</h2>
     <c:if test="${_isLoggedIn}">
@@ -16,6 +18,7 @@
                 </div>
 
                 <form action="/login/token/${tokenId}" method="post">
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                     <input type="hidden" name="tokenKey" value="${tokenKey}" />
                     <div>
                         <label for="remember-me">
@@ -41,6 +44,7 @@
                     Your login link has expired!
                 </div>
                 <form action="/login/token/${tokenId}" method="post">
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                     <input type="hidden" name="tokenKey" value="${tokenKey}" />
                     <button type="submit" class="c-Button__primary">Send new link</button>
                 </form>

--- a/view/src/main/webapp/WEB-INF/jsp/members/usersIndex/header.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/members/usersIndex/header.jspx
@@ -7,6 +7,7 @@
 	 version="2.0">
 
     <!--@elvariable id="memberCategory" type="org.xcolab.client.members.pojo.MemberCategory"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
     
 	<div id="bread" class="pro">
 		<a href="/members"><spring:message code="colab.breadcrums.community"/> </a>&#160; <img
@@ -55,6 +56,7 @@
 				<c:set var="filterURL" value="/members?sortFilterPage.sortColumn=${sortFilterPage.sortColumn}&amp;sortFilterPage.sortAscending=${sortFilterPage.sortAscending}&amp;memberCategory=${memberCategoryParam}" />
 
 				<form action="${filterURL }" id="filterUsersForm" method="post">
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                     <spring:message code="community.page.members.search.placeholder" var="placeHolder"/>
 					<input class="comm_search" type="text" value="${sortFilterPage.filter }" placeholder="${placeHolder}" name="filter" />
 					<button type="submit" class="c-Button__primary"><spring:message code="community.page.members.search.button.search"/></button>

--- a/view/src/main/webapp/WEB-INF/jsp/profile/editUserProfile.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/profile/editUserProfile.jspx
@@ -16,6 +16,7 @@
 	<!--@elvariable id="permissions" type="org.xcolab.portlets.userprofile.utils.UserProfilePermissions"-->
     <!--@elvariable id="currentUserProfile" type="org.xcolab.view.pages.profile.wrappers.UserProfileWrapper"-->
     <!--@elvariable id="memberCategories" type="java.util.List<org.xcolab.client.members.pojo.MemberCategory>"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
 	<c:if test="${updateError}">
 		<script type="text/javascript" >
@@ -364,6 +365,7 @@
 					<td class="actionColumn">
                         <spring:message code="profile.account.delete.question" arguments="${_colabName}" var="deleteMsg"/>
 						<form action="${deleteProfileUrl}" method="post" onsubmit="confirm('${deleteMsg}')">
+                            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 							<button type="submit" class="c-Button__secondary small"><spring:message code="profile.account.delete.button"/></button>
 						</form>
 					</td>

--- a/view/src/main/webapp/WEB-INF/jsp/profile/showUserProfile.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/profile/showUserProfile.jspx
@@ -11,6 +11,7 @@
 <!--@elvariable id="permissions" type="org.xcolab.view.pages.profile.utils.UserProfilePermissions"-->
 <!--@elvariable id="userBean" type="org.xcolab.view.pages.profile.beans.UserBean"-->
 <!--@elvariable id="currentUserProfile" type="org.xcolab.view.pages.profile.wrappers.UserProfileWrapper"-->
+<!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
 <!-- SNP -->
 <!--@elvariable id="isSnpActive" type="java.lang.Boolean"-->
@@ -305,6 +306,7 @@
                         </c:when>
                         <c:otherwise>
                             <form action="/snp/socialnetworkprize" method="post">
+                                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                                 <div class="checkbox">
                                     <label>
                                         <input type="checkbox" name="acceptTos" />

--- a/view/src/main/webapp/WEB-INF/jsp/proposals/integratedProposalImpact.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/proposals/integratedProposalImpact.jspx
@@ -26,6 +26,7 @@
         <!--@elvariable id="proposalToModelMap" type="java.util.Map<java.lang.String, org.xcolab.view.pages.proposals.impact.ProposalSimulationScenarioRegionWrapper>"-->
         <!--@elvariable id="impactIterations" type="java.util.List<org.xcolab.client.contest.pojo.impact.ImpactIteration>"-->
         <!--@elvariable id="impactSerieses" type="java.util.List<org.xcolab.view.pages.proposals.impact.ProposalImpactSeries>"-->
+        <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
         <jsp:directive.include file="./proposalDetails/header.jspx"/>
 
@@ -128,6 +129,7 @@
                         <c:set var="updateProposalScenarioURL" value="${proposal.proposalUrl}/tab/IMPACT" />
 
                         <form action="${updateProposalScenarioURL}" id="updateProposalScenarioForm" method="post">
+                            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                             <input type="text" id="proposalScenarioId" name="scenarioId" class="hidden"/>
                             <input type="text" id="scenarioModelId" name="modelId" class="hidden"/>
                             <input type="text" id="isConsolidatedScenario" name="isConsolidatedScenario" class="hidden"/>

--- a/view/src/main/webapp/WEB-INF/jsp/proposals/proposalAdmin.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/proposals/proposalAdmin.jspx
@@ -10,6 +10,7 @@
 		<xcolab:script src="${_themeJsFolder}/proposals/copyProposalWidget.js"/>
 
 		<!--@elvariable id="availableRibbons" type="java.util.List<org.xcolab.client.contest.pojo.phases.ContestPhaseRibbonType>"-->
+        <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
 		<jsp:directive.include file="./init_proposal_tab.jspx" />
 
@@ -34,6 +35,7 @@
 								<input type='radio' value='true' name='planOpen' ${proposal.open ? "checked='checked'" : ''} />Anyone<br />
 							]]>
 
+                                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                                 <a class="c-Button__primary" href="javascript:;" onclick="jQuery(this).parents('form').submit();">
                                     Save
                                 </a>
@@ -52,6 +54,7 @@
 
 
 						<form action="${assignRibbonURL }" method="post">
+                            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 							<select name="ribbon" style="width: 374px;">
 								<option value="-1">no ribbon</option>
 								<c:forEach var="ribbon" items="${availableRibbons }">
@@ -81,6 +84,7 @@
 						<c:set var="deleteProposalURL" value="${proposal.proposalUrl}/tab/ADMIN/deleteProposal?contestId=${contest.contestPK }&amp;contestUrlName=${contest.contestUrlName }&amp;proposalId=${proposal.proposalId }&amp;delete=true" />
 
 						<form action="${deleteProposalURL }" method="post" id="deleteProposalForm">
+                            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 							<a class="c-Button__primary" href="javascript:;" onclick="if(!confirm('Are you sure you want to proceed with removal?')){ return false; } jQuery('#deleteProposalForm').submit();">
 								DELETE ${contestType.proposalName}
 							</a>
@@ -97,6 +101,7 @@
 				<c:set var="promoteProposalURL" value="${proposal.proposalUrl}/tab/ADMIN/promoteProposal?contestId=${contest.contestPK }&amp;contestUrlName=${contest.contestUrlName }&amp;proposalId=${proposal.proposalId }&amp;contestPhaseId=${proposal.contestPhase.contestPhasePK}" />
 
 				<form action="${promoteProposalURL }" method="post">
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 					<div class="addpropbox ${addBlueClass ? 'blue' : '' }">
 						<strong>Promote ${contestType.proposalName} to latest ${contestType.contestName} phase</strong>
 						<div>
@@ -161,7 +166,8 @@
 					<c:set var="count" value="1" scope="page" />
 						<c:forEach items="${proposal.membershipRequests}" var="request">
 							<form action="${replyToMembershipRequest }" method="post" style="padding: 10px 0; ${count lt fn:length(proposal.membershipRequests) ? 'border-bottom: 1px solid gray;' :''}">
-								<proposalsPortlet:userLinkSimple userId="${request.requestUser.userId}" text="${request.requestUser.firstName} ${request.requestUser.lastName} (${request.requestUser.screenName})" />
+                                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                                <proposalsPortlet:userLinkSimple userId="${request.requestUser.userId}" text="${request.requestUser.firstName} ${request.requestUser.lastName} (${request.requestUser.screenName})" />
 								<div>${request.membershipRequest.comments }</div>
 								<input type="hidden" name="requestId" value="${request.membershipRequest.membershipRequestId}" />
 								<div style="margin-top: 10px;">

--- a/view/src/main/webapp/WEB-INF/jsp/proposals/proposalDetails_edit.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/proposals/proposalDetails_edit.jspx
@@ -11,6 +11,7 @@
 <xcolab:layout  title="${proposal.name} - Edit">
     <!--@elvariable id="isMove" type="java.lang.Boolean"-->
     <!--@elvariable id="hasUnmappedSections" type="java.lang.Boolean"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
     <jsp:directive.include file="./init_proposal.jspx"/>
 
@@ -114,6 +115,7 @@
 
 
         <form action="${contest.proposalLogoPath}images/upload" method="post" enctype="multipart/form-data" target="_fileUploadFrame" id="fileUploadForm">
+            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
             <input type="file" name="file" id="fileUploadInput" />
         </form>
 

--- a/view/src/main/webapp/WEB-INF/tags/collab/discussion/comments.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/collab/discussion/comments.tagx
@@ -24,6 +24,7 @@
         <!--@elvariable id="shareUrl" type="java.lang.String"-->
         <!--@elvariable id="reportTargets" type="java.util.List<org.xcolab.client.flagging.pojo.ReportTarget>"-->
         <!--@elvariable id="ontologySpaces" type="java.util.List<org.xcolab.client.contest.pojo.ontology.OntologySpace>"-->
+        <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
 		<xcolab:loadCkEditor />
 

--- a/view/src/main/webapp/WEB-INF/tags/collab/discussion/comments.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/collab/discussion/comments.tagx
@@ -23,6 +23,7 @@
         <!--@elvariable id="shareTitle" type="java.lang.String"-->
         <!--@elvariable id="shareUrl" type="java.lang.String"-->
         <!--@elvariable id="reportTargets" type="java.util.List<org.xcolab.client.flagging.pojo.ReportTarget>"-->
+        <!--@elvariable id="ontologySpaces" type="java.util.List<org.xcolab.client.contest.pojo.ontology.OntologySpace>"-->
 
 		<xcolab:loadCkEditor />
 
@@ -230,6 +231,7 @@
 				<div class="c-Comment__new">
 					<c:set var="addCommentURL" value="/discussions/addDiscussionMessage?proposalId=${proposalId}&amp;contestId=${sharedColabId}" />
 					<form id="addCommentForm" action="${addCommentURL }#addCommentForm" method="post">
+                        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" id="_csrf"/>
                         <input name="threadId" class="title text hidden" maxlength="255" value="${thread.threadId}" />
 						<input type="hidden" name="uuid" id="filtering_uuid"/>
 						<textarea id="messageContent" name="description"  class="rte-editorPlaceholder c-Comment__box commentContent"><!-- --></textarea>

--- a/view/src/main/webapp/WEB-INF/tags/editButtons.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/editButtons.tagx
@@ -8,15 +8,19 @@
     <jsp:directive.attribute name="elementId" type="java.lang.String" required="false" rtexprvalue="true" description="Element id" />
     <jsp:directive.attribute name="dirtyCheck" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Whether the dirty check is enabled" />
 
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
     <c:set var="createNewElementFormURL" value="${baseUrl}/create" />
     <c:set var="updateElementFormURL" value="${baseUrl}/update" />
     <c:set var="deleteElementFormURL" value="${baseUrl}/delete/${elementId}" />
 
     <form action="${deleteElementFormURL}" id="deleteElementForm" method="post" style="visibility: hidden;" >
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
         <!-- -->
     </form>
 
     <form action="${createNewElementFormURL}" id="createNewElementForm" method="post" style="visibility: hidden;" >
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
         <!-- -->
     </form>
 

--- a/view/src/main/webapp/WEB-INF/tags/layout.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/layout.tagx
@@ -97,6 +97,8 @@
     <!--@elvariable id="__alertMessage" type="org.xcolab.view.util.entity.flash.AlertMessage"-->
     <!--@elvariable id="__analyticsAttribute" type="org.xcolab.view.util.entity.flash.AnalyticsAttribute"-->
 
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
     <fmt:setLocale value="${_locale}" />
     <fmt:setTimeZone value="${_defaultTimeZone}" />
 
@@ -108,6 +110,10 @@
           lang="en-US" name="description" />
 
     <meta content="${_metaPageKeywords}" lang="en-US" name="keywords" />
+
+    <meta name="_csrf" content="${_csrf.token}"/>
+    <meta name="_csrf_header" content="${_csrf.headerName}"/>
+
     <c:if test="${not empty canonicalUrlRelative}">
         <link rel="canonical" href="${colabUrl}${canonicalUrlRelative}" />
     </c:if>

--- a/view/src/main/webapp/WEB-INF/tags/layout.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/layout.tagx
@@ -165,6 +165,17 @@
         jQuery.noty.defaults.animation.speed = 700;
     </script>
 
+    <!-- Include CSRF tokens in AJAX calls. -->
+    <script type="text/javascript">
+        $.ajaxSetup({
+            beforeSend: function(xhr) {
+                var token = $("meta[name='_csrf']").attr("content");
+                var header = $("meta[name='_csrf_header']").attr("content");
+                xhr.setRequestHeader(header, token);
+            }
+        })
+    </script>
+
     <!-- Typekit (fonts) -->
     <c:choose>
         <c:when test='${request.serverName == "localhost"}'>

--- a/view/src/main/webapp/WEB-INF/tags/layout/modals/flaggingModal.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/layout/modals/flaggingModal.tagx
@@ -4,10 +4,13 @@
           xmlns:spring="http://www.springframework.org/tags"
           version="2.0">
 
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
     <!-- report popup -->
     <spring:message code="homepage.modals.flagging.title" var="modalTitle" />
     <xcolab:modal modalId="flaggingModal" title="${modalTitle}">
         <form method="post" action="/flagging/report" id="popup_flagging_form">
+            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
             <div class="modal-body">
                 <div class="c-Alert__info__message">
                     <spring:message code="homepage.modals.flagging.message" />

--- a/view/src/main/webapp/WEB-INF/tags/layout/modals/forgotPasswordModal.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/layout/modals/forgotPasswordModal.tagx
@@ -8,8 +8,11 @@
     <jsp:directive.attribute name="show" type="java.lang.Boolean" required="true" rtexprvalue="true" description="If true, modal will be shown on load" />
     <jsp:directive.attribute name="screenName" type="java.lang.String" required="false" rtexprvalue="true" description="Screenname, if known" />
 
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
     <xcolab:modal modalId="forgotPasswordModal" title="Password recovery">
         <form method="post" action="/login/resetPassword">
+            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
             <div class="modal-body">
                 <c:choose>
                     <c:when test="${not empty screenName}">

--- a/view/src/main/webapp/WEB-INF/tags/layout/modals/loginModal.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/layout/modals/loginModal.tagx
@@ -11,9 +11,12 @@
     <jsp:directive.attribute name="show" type="java.lang.Boolean" required="true" rtexprvalue="true" description="If true, modal will be shown on load" />
     <jsp:directive.attribute name="authError" type="org.xcolab.view.auth.login.AuthenticationError" required="false" rtexprvalue="true" description="Auth error, if any" />
 
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
     <collab:message code="homepage.modals.login.message" var="loginModalTitle" />
     <xcolab:modal modalId="loginModal" title="${loginModalTitle}">
         <form id="signInForm_form" method="post" action="/login">
+            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
             <div class="modal-body">
                 <c:choose>
                     <c:when test='${authError != null}'>

--- a/view/src/main/webapp/WEB-INF/tags/layout/modals/postRegistrationModal.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/layout/modals/postRegistrationModal.tagx
@@ -8,6 +8,8 @@
     <jsp:directive.attribute name="redirect" type="java.lang.String" required="true" rtexprvalue="true" description="URL to redirect to" />
     <jsp:directive.attribute name="member" type="org.xcolab.client.members.pojo.Member" required="false" rtexprvalue="true" description="Regigstered member" />
 
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
     <spring:message code="homepage.modals.postreg.title" var="modalTitle"/>
     <xcolab:modal modalId="postRegistrationModal" title="${modalTitle}" size="lg">
         <div class="modal-body">
@@ -16,6 +18,7 @@
             </p>
             <div class="login_popup_box">
                 <form id="postRegister_form" method="post" action="/register/finalize">
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 
                     <div id="error" class="popup-message" style="display: none;">
                         Your user name must only contain alphabetical or numerical characters and your bio must not exceed 2000 characters.

--- a/view/src/main/webapp/WEB-INF/tags/layout/modals/ssoLoginModal.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/layout/modals/ssoLoginModal.tagx
@@ -9,8 +9,11 @@
     <jsp:directive.attribute name="partnerLogoPath" type="java.lang.String" required="true" rtexprvalue="true" description="Path to the partner CoLab's logo" />
     <jsp:directive.attribute name="show" type="java.lang.Boolean" required="false" rtexprvalue="true" description="If true, modal will be shown on load" />
 
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
     <xcolab:modal modalId="ssoLoginModal">
         <form method="post" action="/sso/colab">
+            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
             <div class="modal-body">
                 <div class="text-center">
                     <img style="max-height:55px" src="${partnerLogoPath}" alt="Partner CoLab" />

--- a/view/src/main/webapp/WEB-INF/tags/layout/navbar.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/layout/navbar.tagx
@@ -25,6 +25,7 @@
     <jsp:directive.attribute name="redirect" type="java.lang.String" required="true" rtexprvalue="true" description="Redirect URL for registration link" />
     <!--@elvariable id="contestPages" type="java.util.List<org.xcolab.client.admin.pojo.ContestType>"-->
     <!--@elvariable id="languageSelectItems" type="java.util.List<org.xcolab.util.html.LabelStringValue>"-->
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
 
     <nav class="bs-navbar navbar bs-navbar-unresponsive ${isWhiteBackgound ? 'bs-navbar-white' : 'bs-navbar-gray'}">
         <div class="bs-container-fixed">
@@ -164,6 +165,7 @@
                                     </c:if>
 
                                     <form class="form" role="form" id="signInFormPopup" method="post" action="/login" accept-charset="UTF-8" >
+                                        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                                         <div class="form-group">
                                             <spring:message code="homepage.login.usernameoremail" var="usernameplaceholder"/>
                                             <input name="username" type="text" class="c-Header__login__username form-control" placeholder="${usernameplaceholder}"  />

--- a/view/src/main/webapp/WEB-INF/tags/sendMessageModal.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/sendMessageModal.tagx
@@ -10,6 +10,8 @@
     <jsp:directive.attribute name="subject" type="java.lang.String" required="false" rtexprvalue="true" description="Pre-filled subject"/>
     <jsp:directive.attribute name="content" type="java.lang.String" required="false" rtexprvalue="true" description="Pre-filled content"/>
 
+    <!--@elvariable id="_csrf" type="org.springframework.security.web.csrf.CsrfToken>"-->
+
     <c:set var="showRecipients" value="${empty recipient and empty replyToMessage}"/>
 
     <spring:message var="sendMessageModalTitle" code="message.modal.sendUserMessage" arguments="${recipient.fullName}"/>
@@ -18,6 +20,7 @@
                   title="${not empty recipient ? sendMessageModalTitle : ''}">
         <form method="post" id="messageForm" action="/messaging/sendMessage"
               onSubmit="checkMessageForm(${showRecipients});">
+            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
             <div class="modal-body">
                 <c:choose>
                     <c:when test="${not empty recipient}">

--- a/view/src/test/java/org/xcolab/view/pages/loginregister/ForgotPasswordControllerTest.java
+++ b/view/src/test/java/org/xcolab/view/pages/loginregister/ForgotPasswordControllerTest.java
@@ -28,7 +28,10 @@ import org.xcolab.view.util.clienthelpers.AdminClientMockerHelper;
 import org.xcolab.view.util.clienthelpers.EmailTemplateClientMockerHelper;
 import org.xcolab.view.util.clienthelpers.MembersClientMockerHelper;
 
+import static org.springframework.security.test.web.servlet.request
+        .SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
 
 
 @RunWith(PowerMockRunner.class)
@@ -93,6 +96,7 @@ public class ForgotPasswordControllerTest {
     public void passwordUpdateFailsWhenScreenNameNotPassed() throws Exception {
 
         this.mockMvc.perform(post("/login/resetPassword")
+                .with(csrf())
         );
 
         PowerMockito.verifyStatic(Mockito.never());
@@ -104,6 +108,7 @@ public class ForgotPasswordControllerTest {
 
 
         this.mockMvc.perform(post("/login/resetPassword")
+                .with(csrf())
                 .param("screenNameOrEmail", "superuser"));
 
         PowerMockito.verifyStatic(Mockito.times(1));

--- a/view/src/test/java/org/xcolab/view/pages/loginregister/LoginRegisterControllerTest.java
+++ b/view/src/test/java/org/xcolab/view/pages/loginregister/LoginRegisterControllerTest.java
@@ -35,6 +35,8 @@ import java.util.ArrayList;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
+import static org.springframework.security.test.web.servlet.request
+        .SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -116,6 +118,7 @@ public class LoginRegisterControllerTest {
     public void registrationFailsWhenInvalidDataPostedAndSendsUserBackToForm() throws Exception {
 
         this.mockMvc.perform(post("/register")
+                .with(csrf())
                 .param("screenName", "")
                 .param("email", "")
                 .param("imageId", "")
@@ -140,6 +143,7 @@ public class LoginRegisterControllerTest {
     public void registrationWorksAndDoLoginAndUserRedirectedToHome() throws Exception {
 
         this.mockMvc.perform(post("/register")
+                .with(csrf())
                 .param("screenName", "username")
                 .param("email", "username@gmail.com")
                 .param("imageId", "")
@@ -163,6 +167,7 @@ public class LoginRegisterControllerTest {
 
 
         this.mockMvc.perform(post("/api/register/generateScreenName")
+                .with(csrf())
                 .param("firstName", "User")
                 .param("lastName", "Name"))
                 .andExpect(content().string(containsString("screenName")));


### PR DESCRIPTION
Reactivated CSRF support in Spring Security.
Manually added CSRF tokens to all non `<form:form>`-type forms.
Added CSRF to all AJAX calls by including an `$.ajaxSetup` method call in the root layout `layout.tagx` that adds the CSRF token to the request header of each AJAX calls. The CSRF token for that is shipped with each HTML page in the meta tag `_csrf`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/22)
<!-- Reviewable:end -->
