### PR TITLE
[COLAB-2107] Check Contest Schedule Validity

### DIFF
--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/SchedulesTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/SchedulesTabController.java
@@ -41,6 +41,9 @@ public class SchedulesTabController extends AbstractTabController {
     private static final String SCHEDULE_CHANGE_ERROR_MESSAGE =
             "This schedule is used in at least one contest that has already started. "
                     + "Please make sure you only change future phases.";
+    private static final String SCHEDULE_CHANGE_INVALID_MESSAGE =
+            "This schedule is invalid. "
+                    + "Please make sure there is no gap or overlap between two adjacent phases";
 
     @ModelAttribute("currentTabWrapped")
     @Override
@@ -150,6 +153,10 @@ public class SchedulesTabController extends AbstractTabController {
 
         if (!contestScheduleBean.areContestsCompatibleWithSchedule()) {
             result.reject(CONTEST_SCHEDULE_BEAN_ATTRIBUTE_KEY, SCHEDULE_CHANGE_ERROR_MESSAGE);
+        }
+
+        if (!contestScheduleBean.isValidSchedule()) {
+            result.reject(CONTEST_SCHEDULE_BEAN_ATTRIBUTE_KEY, SCHEDULE_CHANGE_INVALID_MESSAGE);
         }
 
         if (result.hasErrors()) {

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestScheduleBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestScheduleBean.java
@@ -10,6 +10,7 @@ import org.xcolab.util.http.caching.CacheName;
 import org.xcolab.view.pages.contestmanagement.beans.ContestPhaseBean;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -115,6 +116,20 @@ public class ContestScheduleBean {
 
     public boolean isUsedInNonEmptyContest() {
         return contestSchedule.isUsedInNonEmptyContest();
+    }
+
+    public boolean isValidSchedule() {
+        boolean isValid = true;
+        Date prevEndDate = null;
+        for (ContestPhaseBean contestPhase : schedulePhases) {
+            Date curStartDate = contestPhase.getPhaseStartDate();
+            if (prevEndDate != null && !curStartDate.equals(prevEndDate)) {
+                isValid = false;
+                break;
+            }
+            prevEndDate = contestPhase.getPhaseEndDate();
+        }
+        return isValid;
     }
 
     public boolean areContestsCompatibleWithSchedule() {

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
@@ -309,21 +309,21 @@
                 format: 'm/d/Y H:i',
                 onChangeDateTime: function (dateTimePickerDateString, inst) {
                     var dateTimePickerIndex = parseInt(inst[0].getAttribute("data-index-attribute"));
-                    var nextDateTimePicker = document.querySelector('[data-index-attribute="' + (dateTimePickerIndex + 1) + '"]');
-                    if (nextDateTimePicker.value != undefined) {
+                    var nextDateTimePicker = $('[data-index-attribute="' + (dateTimePickerIndex + 1) + '"]');
+                    if (nextDateTimePicker.val() != undefined) {
                         try {
-                            var nextDateTimePickerDate = new Date(nextDateTimePicker.value);
+                            var nextDateTimePickerDate = new Date(nextDateTimePicker.val());
                             var dateTimePickerDate = new Date(dateTimePickerDateString);
                             if (dateTimePickerDate > nextDateTimePickerDate) {
-                                nextDateTimePicker.value = inst.val();
+                                nextDateTimePicker.attr("value", inst.val());
                             }
                         } catch (e) {
                             console.log("Couldn't parse nextDateTimePickerDate", e);
                         }
                     }
                     if (dateTimePickerIndex > 0 && dateTimePickerIndex % 2 === 0) {
-                        var prevDateTimePicker = document.querySelector('[data-index-attribute="' + (dateTimePickerIndex - 1) + '"]');
-                        prevDateTimePicker.value = inst.val();
+                        var prevDateTimePicker = $('[data-index-attribute="' + (dateTimePickerIndex - 1) + '"]');
+                        prevDateTimePicker.attr("value", inst.val());
                     }
                 }
             });

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
@@ -181,8 +181,7 @@
                                                 data-index-attribute="${dateTimePickerIndex + 1}"
                                                 data-select-attribute="datetimepicker"
                                                 data-form-name="phaseEndDateFormatted"
-                                                readonly="${contestScheduleBean.usedInNonEmptyContest and schedulePhase.contestPhase.ended}"
-                                                disabled="true"
+                                                readonly="true"
                                             />
 
                                 </td>

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
@@ -182,6 +182,7 @@
                                                 data-select-attribute="datetimepicker"
                                                 data-form-name="phaseEndDateFormatted"
                                                 readonly="${contestScheduleBean.usedInNonEmptyContest and schedulePhase.contestPhase.ended}"
+                                                disabled="true"
                                             />
 
                                 </td>
@@ -307,10 +308,8 @@
                 weeks: true,
                 format: 'm/d/Y H:i',
                 onChangeDateTime: function (dateTimePickerDateString, inst) {
-                    var dateTimePickerIndex = inst[0].getAttribute("data-index-attribute");
-                    var nexDateTimePickerIndex = parseInt(dateTimePickerIndex) + 1;
-                    var nextDateTimePicker = document.querySelectorAll('[data-index-attribute="' + nexDateTimePickerIndex + '"]');
-                    nextDateTimePicker = nextDateTimePicker[0];
+                    var dateTimePickerIndex = parseInt(inst[0].getAttribute("data-index-attribute"));
+                    var nextDateTimePicker = document.querySelector('[data-index-attribute="' + (dateTimePickerIndex + 1) + '"]');
                     if (nextDateTimePicker.value != undefined) {
                         try {
                             var nextDateTimePickerDate = new Date(nextDateTimePicker.value);
@@ -321,6 +320,10 @@
                         } catch (e) {
                             console.log("Couldn't parse nextDateTimePickerDate", e);
                         }
+                    }
+                    if (dateTimePickerIndex > 0 && dateTimePickerIndex % 2 === 0) {
+                        var prevDateTimePicker = document.querySelector('[data-index-attribute="' + (dateTimePickerIndex - 1) + '"]');
+                        prevDateTimePicker.value = inst.val();
                     }
                 }
             });


### PR DESCRIPTION
This PR implements a contest schedule validity check when an admin user tries to change a schedule. If the start date of a contest phase is not equal to the end date of the previous contest phase, the changed schedule is not saved an a warning is displayed.

Additionally, the client side is modified to complement those changes. When a contest start date is changed, the previous contest end date is automatically set to that same date. The end date input field is now disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/24)
<!-- Reviewable:end -->
