### PR TITLE
[COLAB-1176] Automatic Platform-wide Role Deletion

### DIFF
--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/ContestTeamMemberClient.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/ContestTeamMemberClient.java
@@ -104,17 +104,12 @@ public class ContestTeamMemberClient {
     }
 
     public List<ContestTeamMember> getTeamMembers(Long userId, Long contestId, Long roleId) {
-        ListQuery<ContestTeamMemberDto> query = contestTeamMemberResource.list();
-        if (userId != null) {
-            query = query.optionalQueryParam("userId", userId);
-        }
-        if (contestId != null) {
-            query = query.optionalQueryParam("contestId", contestId);
-        }
-        if (roleId != null) {
-            query = query.optionalQueryParam("roleId", roleId);
-        }
-        return DtoUtil.toPojos(query.execute(), contestService);
+        return DtoUtil.toPojos(contestTeamMemberResource.list()
+                .optionalQueryParam("userId", userId)
+                .optionalQueryParam("contestId", contestId)
+                .optionalQueryParam("roleId", roleId)
+                .withCache(CacheName.CONTEST_DETAILS)
+                .execute(), contestService);
     }
     public List<ContestTeamMember> getTeamMembers(Long categoryId, Long contestYear) {
         return DtoUtil.toPojos(contestTeamMemberResource.service("getByContestYear",ContestTeamMemberDto.TYPES.getTypeReference())

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/ContestTeamMemberClient.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/ContestTeamMemberClient.java
@@ -10,6 +10,7 @@ import org.xcolab.util.http.caching.CacheName;
 import org.xcolab.util.http.client.RestResource;
 import org.xcolab.util.http.client.RestResource1;
 import org.xcolab.util.http.client.RestService;
+import org.xcolab.util.http.client.queries.ListQuery;
 import org.xcolab.util.http.dto.DtoUtil;
 
 import java.util.ArrayList;
@@ -93,7 +94,7 @@ public class ContestTeamMemberClient {
 
     public Map<Long, List<Long>> getContestTeamMembersByRole(Long contestId) {
         Map<Long, List<Long>> teamRoleToUsersMap = new TreeMap<>();
-        for (ContestTeamMember ctm : getTeamMembers(contestId)) {
+        for (ContestTeamMember ctm : getTeamMembers(null, contestId, null)) {
             List<Long> roleUsers =
                     teamRoleToUsersMap.computeIfAbsent(ctm.getRoleId(), k -> new ArrayList<>());
 
@@ -102,11 +103,18 @@ public class ContestTeamMemberClient {
         return teamRoleToUsersMap;
     }
 
-    public List<ContestTeamMember> getTeamMembers(Long contestId) {
-        return DtoUtil.toPojos(contestTeamMemberResource.list()
-                .optionalQueryParam("contestId", contestId)
-                .withCache(CacheName.CONTEST_DETAILS)
-                .execute(), contestService);
+    public List<ContestTeamMember> getTeamMembers(Long userId, Long contestId, Long roleId) {
+        ListQuery<ContestTeamMemberDto> query = contestTeamMemberResource.list();
+        if (userId != null) {
+            query = query.optionalQueryParam("userId", userId);
+        }
+        if (contestId != null) {
+            query = query.optionalQueryParam("contestId", contestId);
+        }
+        if (roleId != null) {
+            query = query.optionalQueryParam("roleId", roleId);
+        }
+        return DtoUtil.toPojos(query.execute(), contestService);
     }
     public List<ContestTeamMember> getTeamMembers(Long categoryId, Long contestYear) {
         return DtoUtil.toPojos(contestTeamMemberResource.service("getByContestYear",ContestTeamMemberDto.TYPES.getTypeReference())

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/ContestTeamMemberClient.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/ContestTeamMemberClient.java
@@ -10,7 +10,6 @@ import org.xcolab.util.http.caching.CacheName;
 import org.xcolab.util.http.client.RestResource;
 import org.xcolab.util.http.client.RestResource1;
 import org.xcolab.util.http.client.RestService;
-import org.xcolab.util.http.client.queries.ListQuery;
 import org.xcolab.util.http.dto.DtoUtil;
 
 import java.util.ArrayList;
@@ -103,9 +102,9 @@ public class ContestTeamMemberClient {
         return teamRoleToUsersMap;
     }
 
-    public List<ContestTeamMember> getTeamMembers(Long userId, Long contestId, Long roleId) {
+    public List<ContestTeamMember> getTeamMembers(Long memberId, Long contestId, Long roleId) {
         return DtoUtil.toPojos(contestTeamMemberResource.list()
-                .optionalQueryParam("userId", userId)
+                .optionalQueryParam("memberId", memberId)
                 .optionalQueryParam("contestId", contestId)
                 .optionalQueryParam("roleId", roleId)
                 .withCache(CacheName.CONTEST_DETAILS)

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/ContestTeamMemberClientUtil.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/ContestTeamMemberClientUtil.java
@@ -50,9 +50,8 @@ public final class ContestTeamMemberClientUtil {
         return client.getContestTeamMembersByRole(contestId);
     }
 
-    public static List<ContestTeamMember> getTeamMembers(
-            Long contestId) {
-        return client.getTeamMembers(contestId);
+    public static List<ContestTeamMember> getTeamMembers(Long userId, Long contestId, Long roleId) {
+        return client.getTeamMembers(userId, contestId, roleId);
     }
     public static List<ContestTeamMember> getTeamMembers(Long categoryId, Long contestYear) {
         return client.getTeamMembers(categoryId, contestYear);

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/ContestTeamMemberClientUtil.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/ContestTeamMemberClientUtil.java
@@ -50,8 +50,8 @@ public final class ContestTeamMemberClientUtil {
         return client.getContestTeamMembersByRole(contestId);
     }
 
-    public static List<ContestTeamMember> getTeamMembers(Long userId, Long contestId, Long roleId) {
-        return client.getTeamMembers(userId, contestId, roleId);
+    public static List<ContestTeamMember> getTeamMembers(Long memberId, Long contestId, Long roleId) {
+        return client.getTeamMembers(memberId, contestId, roleId);
     }
     public static List<ContestTeamMember> getTeamMembers(Long categoryId, Long contestYear) {
         return client.getTeamMembers(categoryId, contestYear);

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
@@ -378,7 +378,7 @@ public class Contest extends AbstractContest implements Serializable {
         if (contestTeamMembersByRole == null) {
             contestTeamMembersByRole = new TreeMap<>();
             final List<ContestTeamMember> teamMembers =
-                    contestTeamMemberClient.getTeamMembers(this.getContestPK());
+                    contestTeamMemberClient.getTeamMembers(null, this.getContestPK(), null);
             for (ContestTeamMember teamMember : teamMembers) {
                 try {
                     ContestTeamMemberRole role = contestTeamMemberClient

--- a/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/contestteammember/ContestTeamMemberDao.java
+++ b/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/contestteammember/ContestTeamMemberDao.java
@@ -17,9 +17,9 @@ public interface ContestTeamMemberDao {
 
     boolean update(ContestTeamMember contestTeamMember);
 
-    List<ContestTeamMember> findByGiven(Long userId, Long contestId, Long roleId);
+    List<ContestTeamMember> findByGiven(Long memberId, Long contestId, Long roleId);
 
-    ContestTeamMember findOneBy(Long userId, Long contestId, Long roleId);
+    ContestTeamMember findOneBy(Long memberId, Long contestId, Long roleId);
 
     List<ContestTeamMember> findContestYear(Long categoryId, Long contestYear);
 }

--- a/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/contestteammember/ContestTeamMemberDao.java
+++ b/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/contestteammember/ContestTeamMemberDao.java
@@ -17,9 +17,9 @@ public interface ContestTeamMemberDao {
 
     boolean update(ContestTeamMember contestTeamMember);
 
-    List<ContestTeamMember> findByGiven(Long contestId);
+    List<ContestTeamMember> findByGiven(Long userId, Long contestId, Long roleId);
 
-    ContestTeamMember findOneBy(Long memberId, Long contestId, Long roleId);
+    ContestTeamMember findOneBy(Long userId, Long contestId, Long roleId);
 
     List<ContestTeamMember> findContestYear(Long categoryId, Long contestYear);
 }

--- a/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/contestteammember/ContestTeamMemberDaoImpl.java
+++ b/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/contestteammember/ContestTeamMemberDaoImpl.java
@@ -67,10 +67,10 @@ public class ContestTeamMemberDaoImpl implements ContestTeamMemberDao{
 
     }
     @Override
-    public ContestTeamMember findOneBy(Long userId, Long contestId, Long roleId) {
+    public ContestTeamMember findOneBy(Long memberId, Long contestId, Long roleId) {
 
         final Record record =  this.dslContext.selectFrom(CONTEST_TEAM_MEMBER)
-                .where(CONTEST_TEAM_MEMBER.USER_ID.eq(userId))
+                .where(CONTEST_TEAM_MEMBER.USER_ID.eq(memberId))
                 .and(CONTEST_TEAM_MEMBER.CONTEST_ID.eq(contestId))
                 .and(CONTEST_TEAM_MEMBER.ROLE_ID.eq(roleId))
                 .fetchOne();
@@ -92,12 +92,12 @@ public class ContestTeamMemberDaoImpl implements ContestTeamMemberDao{
     }
 
     @Override
-    public List<ContestTeamMember> findByGiven(Long userId, Long contestId, Long roleId) {
+    public List<ContestTeamMember> findByGiven(Long memberId, Long contestId, Long roleId) {
         final SelectQuery<Record> query = dslContext.select()
                 .from(CONTEST_TEAM_MEMBER).getQuery();
 
-        if (userId != null) {
-            query.addConditions(CONTEST_TEAM_MEMBER.USER_ID.eq(userId));
+        if (memberId != null) {
+            query.addConditions(CONTEST_TEAM_MEMBER.USER_ID.eq(memberId));
         }
         if (contestId != null) {
             query.addConditions(CONTEST_TEAM_MEMBER.CONTEST_ID.eq(contestId));

--- a/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/contestteammember/ContestTeamMemberDaoImpl.java
+++ b/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/contestteammember/ContestTeamMemberDaoImpl.java
@@ -67,10 +67,10 @@ public class ContestTeamMemberDaoImpl implements ContestTeamMemberDao{
 
     }
     @Override
-    public ContestTeamMember findOneBy(Long memberId, Long contestId, Long roleId) {
+    public ContestTeamMember findOneBy(Long userId, Long contestId, Long roleId) {
 
         final Record record =  this.dslContext.selectFrom(CONTEST_TEAM_MEMBER)
-                .where(CONTEST_TEAM_MEMBER.USER_ID.eq(memberId))
+                .where(CONTEST_TEAM_MEMBER.USER_ID.eq(userId))
                 .and(CONTEST_TEAM_MEMBER.CONTEST_ID.eq(contestId))
                 .and(CONTEST_TEAM_MEMBER.ROLE_ID.eq(roleId))
                 .fetchOne();
@@ -92,12 +92,18 @@ public class ContestTeamMemberDaoImpl implements ContestTeamMemberDao{
     }
 
     @Override
-    public List<ContestTeamMember> findByGiven(Long contestId) {
+    public List<ContestTeamMember> findByGiven(Long userId, Long contestId, Long roleId) {
         final SelectQuery<Record> query = dslContext.select()
                 .from(CONTEST_TEAM_MEMBER).getQuery();
 
+        if (userId != null) {
+            query.addConditions(CONTEST_TEAM_MEMBER.USER_ID.eq(userId));
+        }
         if (contestId != null) {
             query.addConditions(CONTEST_TEAM_MEMBER.CONTEST_ID.eq(contestId));
+        }
+        if (roleId != null) {
+            query.addConditions(CONTEST_TEAM_MEMBER.ROLE_ID.eq(roleId));
         }
         return query.fetchInto(ContestTeamMember.class);
     }

--- a/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/web/ContestTeamMembersController.java
+++ b/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/web/ContestTeamMembersController.java
@@ -59,11 +59,11 @@ public class ContestTeamMembersController {
 
     @RequestMapping(value = "/contestTeamMembers", method = {RequestMethod.GET, RequestMethod.HEAD})
     public List<ContestTeamMember> getContestTeamMembers(
-            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Long memberId,
             @RequestParam(required = false) Long contestId,
             @RequestParam(required = false) Long roleId
     ) {
-        return contestTeamMemberDao.findByGiven(userId, contestId, roleId);
+        return contestTeamMemberDao.findByGiven(memberId, contestId, roleId);
     }
 
     @RequestMapping(value = "/contestTeamMembers/getByContestYear", method = {RequestMethod.GET, RequestMethod.HEAD})

--- a/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/web/ContestTeamMembersController.java
+++ b/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/web/ContestTeamMembersController.java
@@ -59,9 +59,11 @@ public class ContestTeamMembersController {
 
     @RequestMapping(value = "/contestTeamMembers", method = {RequestMethod.GET, RequestMethod.HEAD})
     public List<ContestTeamMember> getContestTeamMembers(
-            @RequestParam(required = false) Long contestId
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Long contestId,
+            @RequestParam(required = false) Long roleId
     ) {
-        return contestTeamMemberDao.findByGiven(contestId);
+        return contestTeamMemberDao.findByGiven(userId, contestId, roleId);
     }
 
     @RequestMapping(value = "/contestTeamMembers/getByContestYear", method = {RequestMethod.GET, RequestMethod.HEAD})

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestTeamWrapper.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestTeamWrapper.java
@@ -53,15 +53,14 @@ public class ContestTeamWrapper {
     }
 
     private void assignMemberRoleToUser(MemberRole memberRole, List<Long> userIds) {
+        Long roleId = memberRole.getRoleId();
         for (Long userId : userIds) {
-            Long roleId = memberRole.getRoleId();
             MembersClient.assignMemberRole(userId, roleId);
         }
     }
 
     private void assignMembersToContestWithRole(List<Long> userIds, MemberRole memberRole) {
         for (Long userId : userIds) {
-
             ContestTeamMember contestTeamMember = new ContestTeamMember();
             contestTeamMember.setContestId(contestId);
             contestTeamMember.setUserId(userId);

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestTeamWrapper.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestTeamWrapper.java
@@ -75,15 +75,25 @@ public class ContestTeamWrapper {
         }
     }
 
+    private void removeTeamMember(ContestTeamMember contestTeamMember) {
+        try {
+            ContestTeamMemberClientUtil.deleteContestTeamMember(contestTeamMember.getId_());
+        } catch (UncheckedEntityNotFoundException e) {
+            log.warn("ContestTeamMember {} already deleted", contestTeamMember.getId_());
+        }
+        Long userId = contestTeamMember.getUserId();
+        Long roleId = contestTeamMember.getRoleId();
+        if (ContestTeamMemberClientUtil.getTeamMembers(userId, null, roleId).isEmpty()) {
+            MembersClient.removeMemberRole(userId, roleId);
+        }
+
+    }
+
     private void removeAllContestTeamMembersForContest() {
         List<ContestTeamMember> contestTeamMembers =
-                ContestTeamMemberClientUtil.getTeamMembers(contestId);
+                ContestTeamMemberClientUtil.getTeamMembers(null, contestId, null);
         for (ContestTeamMember contestTeamMember : contestTeamMembers) {
-            try {
-                ContestTeamMemberClientUtil.deleteContestTeamMember(contestTeamMember.getId_());
-            } catch (UncheckedEntityNotFoundException e) {
-                log.warn("ContestTeamMember {} already deleted", contestTeamMember.getId_());
-            }
+            removeTeamMember(contestTeamMember);
         }
     }
 }


### PR DESCRIPTION
This PR implements automatic platform-wide role deletion. If a user is removed from a contest's team members and does not have that specific role in any other contest, this role is removed for the user on the whole platform.

To allow to perform this check, the `findByGiven` method in the `ContestTeamMemberDao` now has three parameters instead of one: `Long userId, Long contestId, Long roleId`. If any of them is null, it is not included in the query. On the client side, the same now applies to `getTeamMembers`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/25)
<!-- Reviewable:end -->
