### PR TITLE
[COLAB-962] Add defaultFlagText to ContestPhaseType

### DIFF
--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/phases/AbstractContestPhaseType.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/phases/AbstractContestPhaseType.java
@@ -15,6 +15,7 @@ abstract class AbstractContestPhaseType implements Serializable {
     private Boolean invisible;
     private Integer pointsaccessible;
     private String defaultpromotiontype;
+    private String defaultflagtext;
 
     public AbstractContestPhaseType() {}
 
@@ -28,12 +29,13 @@ abstract class AbstractContestPhaseType implements Serializable {
         this.invisible = value.invisible;
         this.pointsaccessible = value.pointsaccessible;
         this.defaultpromotiontype = value.defaultpromotiontype;
+        this.defaultflagtext = value.defaultflagtext;
     }
 
     public AbstractContestPhaseType(Long id_, String name, String description,
             String status, Boolean fellowscreeningactivedefault,
             String contestphaseautopromotedefault, Boolean invisible,
-            Integer pointsaccessible, String defaultpromotiontype) {
+            Integer pointsaccessible, String defaultpromotiontype, String defaultflagtext) {
         this.id_ = id_;
         this.name = name;
         this.description = description;
@@ -43,6 +45,7 @@ abstract class AbstractContestPhaseType implements Serializable {
         this.invisible = invisible;
         this.pointsaccessible = pointsaccessible;
         this.defaultpromotiontype = defaultpromotiontype;
+        this.defaultflagtext = defaultflagtext;
     }
 
     public Long getId_() {
@@ -117,6 +120,14 @@ abstract class AbstractContestPhaseType implements Serializable {
         this.defaultpromotiontype = defaultpromotiontype;
     }
 
+    public String getDefaultFlagText() {
+        return this.defaultflagtext;
+    }
+
+    public void setDefaultFlagText(String defaultflagtext) {
+        this.defaultflagtext = defaultflagtext;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -133,6 +144,7 @@ abstract class AbstractContestPhaseType implements Serializable {
         result = prime * result + ((pointsaccessible == null) ? 0 : pointsaccessible.hashCode());
         result = prime * result + ((defaultpromotiontype == null) ? 0
                 : defaultpromotiontype.hashCode());
+        result = prime * result + ((defaultflagtext == null) ? 0 : defaultflagtext.hashCode());
         return result;
     }
 
@@ -211,6 +223,13 @@ abstract class AbstractContestPhaseType implements Serializable {
         } else if (!defaultpromotiontype.equals(other.defaultpromotiontype)) {
             return false;
         }
+        if (defaultflagtext == null) {
+            if (other.defaultflagtext != null) {
+                return false;
+            }
+        } else if (!defaultflagtext.equals(other.defaultflagtext)) {
+            return false;
+        }
         return true;
     }
 
@@ -226,6 +245,7 @@ abstract class AbstractContestPhaseType implements Serializable {
                 ", " + invisible +
                 ", " + pointsaccessible +
                 ", " + defaultpromotiontype +
+                ", " + defaultflagtext +
                 ")";
     }
 }

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/phases/ContestPhase.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/phases/ContestPhase.java
@@ -194,6 +194,15 @@ public class ContestPhase extends AbstractContestPhase {
         return contestClient.getContestPhaseType(this.getContestPhaseType()).getName();
     }
 
+    public String getFlagText() {
+        ContestPhaseType phaseType = getContestPhaseTypeObject();
+        String flagText = phaseType.getDefaultFlagText();
+        if (StringUtils.isEmpty(flagText)) {
+            flagText = phaseType.getName();
+        }
+        return flagText;
+    }
+
     public boolean isEnded() {
         Date now = new Date();
         return (this.getPhaseEndDate() != null) && this.getPhaseEndDate().before(now);

--- a/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/contestphasetype/ContestPhaseTypeDaoImpl.java
+++ b/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/contestphasetype/ContestPhaseTypeDaoImpl.java
@@ -32,6 +32,7 @@ public class ContestPhaseTypeDaoImpl implements ContestPhaseTypeDao{
                 .set(CONTEST_PHASE_TYPE.INVISIBLE, contestPhaseType.getInvisible())
                 .set(CONTEST_PHASE_TYPE.POINTS_ACCESSIBLE, contestPhaseType.getPointsAccessible())
                 .set(CONTEST_PHASE_TYPE.DEFAULT_PROMOTION_TYPE, contestPhaseType.getDefaultPromotionType())
+                .set(CONTEST_PHASE_TYPE.DEFAULT_FLAG_TEXT, contestPhaseType.getDefaultFlagText())
                 .returning(CONTEST_PHASE_TYPE.ID_)
                 .fetchOne();
         if (ret != null) {
@@ -66,6 +67,7 @@ public class ContestPhaseTypeDaoImpl implements ContestPhaseTypeDao{
                 .set(CONTEST_PHASE_TYPE.INVISIBLE, contestPhaseType.getInvisible())
                 .set(CONTEST_PHASE_TYPE.POINTS_ACCESSIBLE, contestPhaseType.getPointsAccessible())
                 .set(CONTEST_PHASE_TYPE.DEFAULT_PROMOTION_TYPE, contestPhaseType.getDefaultPromotionType())
+                .set(CONTEST_PHASE_TYPE.DEFAULT_FLAG_TEXT, contestPhaseType.getDefaultFlagText())
                 .where(CONTEST_PHASE_TYPE.ID_.eq(contestPhaseType.getId_()))
                 .execute() > 0;
     }

--- a/sql/deployments/deployment-2017-09-07__ClimateCoLab.sql
+++ b/sql/deployments/deployment-2017-09-07__ClimateCoLab.sql
@@ -1,0 +1,1 @@
+ALTER TABLE xcolab_ContestPhaseType ADD defaultFlagText VARCHAR(1024) DEFAULT NULL;

--- a/sql/deployments/deployment-2017-09-07__ClimateCoLab.sql
+++ b/sql/deployments/deployment-2017-09-07__ClimateCoLab.sql
@@ -1,1 +1,1 @@
-ALTER TABLE xcolab_ContestPhaseType ADD defaultFlagText VARCHAR(1024) DEFAULT NULL;
+ALTER TABLE xcolab_ContestPhaseType ADD defaultFlagText VARCHAR(60) DEFAULT NULL;

--- a/sql/starter/xcolab-schema.sql
+++ b/sql/starter/xcolab-schema.sql
@@ -529,6 +529,7 @@ CREATE TABLE `xcolab_ContestPhaseType` (
   `invisible` tinyint(4) DEFAULT NULL,
   `pointsAccessible` int(11) DEFAULT NULL,
   `defaultPromotionType` varchar(75) DEFAULT NULL,
+  `defaultFlagText` varchar(1024) DEFAULT NULL,
   PRIMARY KEY (`id_`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/sql/starter/xcolab-schema.sql
+++ b/sql/starter/xcolab-schema.sql
@@ -529,7 +529,7 @@ CREATE TABLE `xcolab_ContestPhaseType` (
   `invisible` tinyint(4) DEFAULT NULL,
   `pointsAccessible` int(11) DEFAULT NULL,
   `defaultPromotionType` varchar(75) DEFAULT NULL,
-  `defaultFlagText` varchar(1024) DEFAULT NULL,
+  `defaultFlagText` varchar(60) DEFAULT NULL,
   PRIMARY KEY (`id_`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/view/src/main/webapp/WEB-INF/tags/proposalsPortlet/contestGridElement.tagx
+++ b/view/src/main/webapp/WEB-INF/tags/proposalsPortlet/contestGridElement.tagx
@@ -79,7 +79,7 @@
                         <div class="c-ContestBox__meta__flag--grey" style="font-size: 13px;"> Winners to be announced </div>
                     </c:when>
                     <c:when test='${not empty contest.activePhase.status}'>
-                        <div class="c-ContestBox__meta__flag--${contestPhaseClosed ? 'grey' : 'color'}"> ${contest.activePhase.name} </div>
+                        <div class="c-ContestBox__meta__flag--${contestPhaseClosed ? 'grey' : 'color'}"> ${contest.activePhase.flagText} </div>
                     </c:when>
                 </c:choose>
             </c:if>


### PR DESCRIPTION
This PR adds the `defaultFlagText` field to the ContestPhaseType. Now, when a Contest does not have a `flagText` set, the `defaultFlagText` of its contest phase's type is displayed instead of the `name`.  If the contest phase's type has no `defaultFlagText` set, the flag text falls back to the `name`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/26)
<!-- Reviewable:end -->
