### PR TITLE
[COLAB-959] Autosave Contest Order Change

### DIFF
--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
@@ -126,6 +126,18 @@ public class OverviewTabController extends AbstractTabController {
         }
     }
 
+    @PostMapping("manager/updateOrder")
+    public void updateContestOrder(HttpServletRequest request,
+            HttpServletResponse response, Model model, Member member,
+            @ModelAttribute ContestOverviewWrapper updateContestOverviewWrapper)
+            throws IOException, InvocationTargetException, IllegalAccessException {
+        if (tabWrapper.getCanEdit()) {
+            response.sendError(403);
+        }
+        updateContestOverviewWrapper.setSelectedMassAction((long) ContestMassActions.ORDER.ordinal());
+        updateContestOverviewWrapper.executeMassAction(request, response);
+    }
+
     @PostMapping("api/massAction")
     public void getExportController(HttpServletRequest request, Model model,
             @ModelAttribute ContestOverviewWrapper updateContestOverviewWrapper,

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
@@ -131,7 +131,7 @@ public class OverviewTabController extends AbstractTabController {
             HttpServletResponse response, Model model, Member member,
             @ModelAttribute ContestOverviewWrapper updateContestOverviewWrapper)
             throws IOException, InvocationTargetException, IllegalAccessException {
-        if (tabWrapper.getCanEdit()) {
+        if (!tabWrapper.getCanEdit()) {
             response.sendError(403);
         }
         updateContestOverviewWrapper.setSelectedMassAction((long) ContestMassActions.ORDER.ordinal());

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
@@ -382,6 +382,7 @@
 			reCalculateWeights();
 			event.stopPropagation(); // Stops some browsers from redirecting.
 			event.preventDefault();
+			updateOrder();
 			return false;
 		}
 
@@ -399,6 +400,25 @@
 				}
 			} while (nextElementInList = nextElementInList.nextSibling)
 		}
+
+		function updateOrder() {
+            var editForm = $('#editForm');
+            var selectedMassAction = $('#selectedMassAction');
+            var selectedMassActionIndex = selectedMassAction.val();
+            selectedMassAction.val(0);
+            $.ajax(editForm.attr("action"), {
+                method: 'POST',
+                data: editForm.serialize(),
+                beforeSend: function (jqXHR, textStatus) {
+                    noty({text: "Updating order...", type: 'information', timeout: false});
+                },
+                success: function (data, textStatus, jqXHR) {
+                    console.log("Result!");
+                    noty({text:"Order updated.", type:'success', killer: true});
+                }
+            });
+            selectedMassAction.val(selectedMassActionIndex);
+        }
 
 		//}());
 		]]>

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
@@ -406,15 +406,17 @@
             var selectedMassAction = $('#selectedMassAction');
             var selectedMassActionIndex = selectedMassAction.val();
             selectedMassAction.val(0);
-            $.ajax(editForm.attr("action"), {
+            $.ajax("/admin/contest/manager/updateOrder", {
                 method: 'POST',
                 data: editForm.serialize(),
                 beforeSend: function (jqXHR, textStatus) {
                     noty({text: "Updating order...", type: 'information', timeout: false});
                 },
                 success: function (data, textStatus, jqXHR) {
-                    console.log("Result!");
-                    noty({text:"Order updated.", type:'success', killer: true});
+                    noty({text: "Order updated.", type: 'success', killer: true});
+                },
+                error: function (jqXHR, textStatus, errorThrown) {
+                    noty({text: "Order update failed.", type: 'error', killer: true});
                 }
             });
             selectedMassAction.val(selectedMassActionIndex);

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
@@ -403,9 +403,6 @@
 
 		function updateOrder() {
             var editForm = $('#editForm');
-            var selectedMassAction = $('#selectedMassAction');
-            var selectedMassActionIndex = selectedMassAction.val();
-            selectedMassAction.val(0);
             $.ajax("/admin/contest/manager/updateOrder", {
                 method: 'POST',
                 data: editForm.serialize(),
@@ -419,7 +416,6 @@
                     noty({text: "Order update failed.", type: 'error', killer: true});
                 }
             });
-            selectedMassAction.val(selectedMassActionIndex);
         }
 
 		//}());


### PR DESCRIPTION
This PR implements an automatic asynchronous contest order update on contest order change over AJAX. A new void-returning controller method is added at the route `"manager/updateOrder"` for performance reasons, since the returned data of `"manager/update"` is not needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/27)
<!-- Reviewable:end -->
