### PR TITLE
[COLAB-2107] Revert contest phase overlap frontend changes

### DIFF
--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
@@ -309,21 +309,21 @@
                 format: 'm/d/Y H:i',
                 onChangeDateTime: function (dateTimePickerDateString, inst) {
                     var dateTimePickerIndex = parseInt(inst[0].getAttribute("data-index-attribute"));
-                    var nextDateTimePicker = $('[data-index-attribute="' + (dateTimePickerIndex + 1) + '"]');
-                    if (nextDateTimePicker.val() != undefined) {
+                    var nextDateTimePicker = document.querySelector('[data-index-attribute="' + (dateTimePickerIndex + 1) + '"]');
+                    if (nextDateTimePicker.value != undefined) {
                         try {
-                            var nextDateTimePickerDate = new Date(nextDateTimePicker.val());
+                            var nextDateTimePickerDate = new Date(nextDateTimePicker.value);
                             var dateTimePickerDate = new Date(dateTimePickerDateString);
                             if (dateTimePickerDate > nextDateTimePickerDate) {
-                                nextDateTimePicker.attr("value", inst.val());
+                                nextDateTimePicker.value = inst.val();
                             }
                         } catch (e) {
                             console.log("Couldn't parse nextDateTimePickerDate", e);
                         }
                     }
                     if (dateTimePickerIndex > 0 && dateTimePickerIndex % 2 === 0) {
-                        var prevDateTimePicker = $('[data-index-attribute="' + (dateTimePickerIndex - 1) + '"]');
-                        prevDateTimePicker.attr("value", inst.val());
+                        var prevDateTimePicker = document.querySelector('[data-index-attribute="' + (dateTimePickerIndex - 1) + '"]');
+                        prevDateTimePicker.value = inst.val();
                     }
                 }
             });

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
@@ -181,7 +181,8 @@
                                                 data-index-attribute="${dateTimePickerIndex + 1}"
                                                 data-select-attribute="datetimepicker"
                                                 data-form-name="phaseEndDateFormatted"
-                                                readonly="true"
+                                                readonly="${contestScheduleBean.usedInNonEmptyContest and schedulePhase.contestPhase.ended}"
+                                                disabled="true"
                                             />
 
                                 </td>

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
@@ -182,7 +182,6 @@
                                                 data-select-attribute="datetimepicker"
                                                 data-form-name="phaseEndDateFormatted"
                                                 readonly="${contestScheduleBean.usedInNonEmptyContest and schedulePhase.contestPhase.ended}"
-                                                disabled="true"
                                             />
 
                                 </td>
@@ -308,8 +307,10 @@
                 weeks: true,
                 format: 'm/d/Y H:i',
                 onChangeDateTime: function (dateTimePickerDateString, inst) {
-                    var dateTimePickerIndex = parseInt(inst[0].getAttribute("data-index-attribute"));
-                    var nextDateTimePicker = document.querySelector('[data-index-attribute="' + (dateTimePickerIndex + 1) + '"]');
+                    var dateTimePickerIndex = inst[0].getAttribute("data-index-attribute");
+                    var nexDateTimePickerIndex = parseInt(dateTimePickerIndex) + 1;
+                    var nextDateTimePicker = document.querySelectorAll('[data-index-attribute="' + nexDateTimePickerIndex + '"]');
+                    nextDateTimePicker = nextDateTimePicker[0];
                     if (nextDateTimePicker.value != undefined) {
                         try {
                             var nextDateTimePickerDate = new Date(nextDateTimePicker.value);
@@ -320,10 +321,6 @@
                         } catch (e) {
                             console.log("Couldn't parse nextDateTimePickerDate", e);
                         }
-                    }
-                    if (dateTimePickerIndex > 0 && dateTimePickerIndex % 2 === 0) {
-                        var prevDateTimePicker = document.querySelector('[data-index-attribute="' + (dateTimePickerIndex - 1) + '"]');
-                        prevDateTimePicker.value = inst.val();
                     }
                 }
             });


### PR DESCRIPTION
This PR reverts the frontend changes of [COLAB-2107]. The end date of the previous contest phase is now not set automatically anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/28)
<!-- Reviewable:end -->
