### PR TITLE
[COLAB-2238] Use Name to Map to Mass Action

### DIFF
--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/ConfirmMassActionController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/ConfirmMassActionController.java
@@ -36,8 +36,7 @@ public class ConfirmMassActionController {
         List<Long> contestIds = massActionConfirmationWrapper.getSelectedContestIds();
         List<Contest> contests = EntityIdListUtil.CONTESTS.fromIdList(contestIds);
 
-        String selectedMassActionName = massActionConfirmationWrapper.getSelectedMassActionName();
-        ContestMassActions actionWrapper = ContestMassActions.valueOf(selectedMassActionName);
+        ContestMassActions actionWrapper = massActionConfirmationWrapper.getSelectedMassAction();
         ContestMassAction action = actionWrapper.getAction();
 
         try {

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/ConfirmMassActionController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/ConfirmMassActionController.java
@@ -36,8 +36,8 @@ public class ConfirmMassActionController {
         List<Long> contestIds = massActionConfirmationWrapper.getSelectedContestIds();
         List<Contest> contests = EntityIdListUtil.CONTESTS.fromIdList(contestIds);
 
-        String massActionName = massActionConfirmationWrapper.getMassActionName();
-        ContestMassActions actionWrapper = ContestMassActions.valueOf(massActionName);
+        String selectedMassActionName = massActionConfirmationWrapper.getSelectedMassActionName();
+        ContestMassActions actionWrapper = ContestMassActions.valueOf(selectedMassActionName);
         ContestMassAction action = actionWrapper.getAction();
 
         try {

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/ConfirmMassActionController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/ConfirmMassActionController.java
@@ -36,8 +36,8 @@ public class ConfirmMassActionController {
         List<Long> contestIds = massActionConfirmationWrapper.getSelectedContestIds();
         List<Contest> contests = EntityIdListUtil.CONTESTS.fromIdList(contestIds);
 
-        int massActionIndex = massActionConfirmationWrapper.getMassActionId();
-        ContestMassActions actionWrapper = ContestMassActions.values()[massActionIndex];
+        String massActionName = massActionConfirmationWrapper.getMassActionName();
+        ContestMassActions actionWrapper = ContestMassActions.valueOf(massActionName);
         ContestMassAction action = actionWrapper.getAction();
 
         try {

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
@@ -56,7 +56,8 @@ public class OverviewTabController extends AbstractTabController {
         Map<String, String> contestMassActionItems = new LinkedHashMap<>();
 
         for (ContestMassActions contestMassAction : ContestMassActions.values()) {
-            contestMassActionItems.put(contestMassAction.name(), contestMassAction.getAction().getDisplayName());
+            contestMassActionItems
+                    .put(contestMassAction.name(), contestMassAction.getAction().getDisplayName());
         }
 
         return contestMassActionItems;
@@ -99,7 +100,8 @@ public class OverviewTabController extends AbstractTabController {
         if (!tabWrapper.getCanEdit()) {
             response.sendError(403);
         }
-        List<Contest> contests = new ArrayList<>(updateContestOverviewWrapper.getContests().values());
+        List<Contest> contests =
+                new ArrayList<>(updateContestOverviewWrapper.getContests().values());
         OrderMassAction orderMassAction = (OrderMassAction) ContestMassActions.ORDER.getAction();
         orderMassAction.execute(contests);
     }
@@ -120,16 +122,12 @@ public class OverviewTabController extends AbstractTabController {
     private String showConfirmationView(Model model,
             ContestOverviewWrapper contestOverviewWrapper) {
         List<Long> contestIds = contestOverviewWrapper.getSelectedContestIds();
-        String selectedMassActionName = contestOverviewWrapper.getSelectedMassActionName();
+        ContestMassActions selectedMassActionWrapper =
+                ContestMassActions.valueOf(contestOverviewWrapper.getSelectedMassActionName());
         model.addAttribute("massActionConfirmationWrapper",
-                new MassActionConfirmationWrapper(contestIds, selectedMassActionName));
+                new MassActionConfirmationWrapper(contestIds, selectedMassActionWrapper));
 
         return CONFIRM_VIEW_PATH;
-    }
-
-    private ContestMassActions getMassActionWrapper(ContestOverviewWrapper contestOverviewWrapper) {
-        String selectedMassActionName = contestOverviewWrapper.getSelectedMassActionName();
-        return ContestMassActions.valueOf(selectedMassActionName);
     }
 
     private void executeMassAction(HttpServletRequest request, HttpServletResponse response,
@@ -137,8 +135,7 @@ public class OverviewTabController extends AbstractTabController {
             throws MassActionRequiresConfirmationException, IOException {
         contestOverviewWrapper.setMemberId(MemberAuthUtil.getMemberId(request));
 
-        ContestMassActions actionWrapper = getMassActionWrapper(contestOverviewWrapper);
-        ContestMassAction action = actionWrapper.getAction();
+        ContestMassAction action = contestOverviewWrapper.getSelectedMassAction();
         List<Long> contestIds = contestOverviewWrapper.getSelectedContestIds();
         List<Contest> contests = EntityIdListUtil.CONTESTS.fromIdList(contestIds);
 

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import org.xcolab.client.contest.pojo.Contest;
 import org.xcolab.client.members.pojo.Member;
-import org.xcolab.util.html.LabelValue;
 import org.xcolab.view.auth.MemberAuthUtil;
 import org.xcolab.view.errors.AccessDeniedPage;
 import org.xcolab.view.pages.contestmanagement.entities.ContestManagerTabs;
@@ -26,7 +25,9 @@ import org.xcolab.view.util.entity.flash.AlertMessage;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -51,12 +52,11 @@ public class OverviewTabController extends AbstractTabController {
 
 
     @ModelAttribute("massActionsItems")
-    public List<LabelValue> populateMassActionsItems(HttpServletRequest request) {
-        List<LabelValue> contestMassActionItems = new ArrayList<>();
+    public Map<String, String> populateMassActionsItems(HttpServletRequest request) {
+        Map<String, String> contestMassActionItems = new HashMap<>();
 
         for (ContestMassActions contestMassAction : ContestMassActions.values()) {
-            contestMassActionItems.add(new LabelValue((long) contestMassAction.ordinal(),
-                    contestMassAction.getAction().getDisplayName()));
+            contestMassActionItems.put(contestMassAction.name(), contestMassAction.getAction().getDisplayName());
         }
 
         return contestMassActionItems;
@@ -120,19 +120,16 @@ public class OverviewTabController extends AbstractTabController {
     private String showConfirmationView(Model model,
             ContestOverviewWrapper contestOverviewWrapper) {
         List<Long> contestIds = contestOverviewWrapper.getSelectedContestIds();
-        int massActionIndex = contestOverviewWrapper.getSelectedMassAction().intValue();
+        String massActionName = contestOverviewWrapper.getSelectedMassAction();
         model.addAttribute("massActionConfirmationWrapper",
-                new MassActionConfirmationWrapper(contestIds, massActionIndex));
+                new MassActionConfirmationWrapper(contestIds, massActionName));
 
         return CONFIRM_VIEW_PATH;
     }
 
     private ContestMassActions getMassActionWrapper(ContestOverviewWrapper contestOverviewWrapper) {
-        int massActionIndex = contestOverviewWrapper.getSelectedMassAction().intValue();
-        if (massActionIndex > ContestMassActions.values().length) {
-            throw new IllegalArgumentException("Illegal mass action index");
-        }
-        return ContestMassActions.values()[massActionIndex];
+        String massActionName = contestOverviewWrapper.getSelectedMassAction();
+        return ContestMassActions.valueOf(massActionName);
     }
 
     private void executeMassAction(HttpServletRequest request, HttpServletResponse response,

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
@@ -25,7 +25,7 @@ import org.xcolab.view.util.entity.flash.AlertMessage;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -53,7 +53,7 @@ public class OverviewTabController extends AbstractTabController {
 
     @ModelAttribute("massActionsItems")
     public Map<String, String> populateMassActionsItems(HttpServletRequest request) {
-        Map<String, String> contestMassActionItems = new HashMap<>();
+        Map<String, String> contestMassActionItems = new LinkedHashMap<>();
 
         for (ContestMassActions contestMassAction : ContestMassActions.values()) {
             contestMassActionItems.put(contestMassAction.name(), contestMassAction.getAction().getDisplayName());

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
@@ -122,8 +122,7 @@ public class OverviewTabController extends AbstractTabController {
     private String showConfirmationView(Model model,
             ContestOverviewWrapper contestOverviewWrapper) {
         List<Long> contestIds = contestOverviewWrapper.getSelectedContestIds();
-        ContestMassActions selectedMassActionWrapper =
-                ContestMassActions.valueOf(contestOverviewWrapper.getSelectedMassActionName());
+        ContestMassActions selectedMassActionWrapper = contestOverviewWrapper.getSelectedMassAction();
         model.addAttribute("massActionConfirmationWrapper",
                 new MassActionConfirmationWrapper(contestIds, selectedMassActionWrapper));
 
@@ -135,7 +134,7 @@ public class OverviewTabController extends AbstractTabController {
             throws MassActionRequiresConfirmationException, IOException {
         contestOverviewWrapper.setMemberId(MemberAuthUtil.getMemberId(request));
 
-        ContestMassAction action = contestOverviewWrapper.getSelectedMassAction();
+        ContestMassAction action = contestOverviewWrapper.getSelectedMassAction().getAction();
         List<Long> contestIds = contestOverviewWrapper.getSelectedContestIds();
         List<Contest> contests = EntityIdListUtil.CONTESTS.fromIdList(contestIds);
 

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/OverviewTabController.java
@@ -120,16 +120,16 @@ public class OverviewTabController extends AbstractTabController {
     private String showConfirmationView(Model model,
             ContestOverviewWrapper contestOverviewWrapper) {
         List<Long> contestIds = contestOverviewWrapper.getSelectedContestIds();
-        String massActionName = contestOverviewWrapper.getSelectedMassAction();
+        String selectedMassActionName = contestOverviewWrapper.getSelectedMassActionName();
         model.addAttribute("massActionConfirmationWrapper",
-                new MassActionConfirmationWrapper(contestIds, massActionName));
+                new MassActionConfirmationWrapper(contestIds, selectedMassActionName));
 
         return CONFIRM_VIEW_PATH;
     }
 
     private ContestMassActions getMassActionWrapper(ContestOverviewWrapper contestOverviewWrapper) {
-        String massActionName = contestOverviewWrapper.getSelectedMassAction();
-        return ContestMassActions.valueOf(massActionName);
+        String selectedMassActionName = contestOverviewWrapper.getSelectedMassActionName();
+        return ContestMassActions.valueOf(selectedMassActionName);
     }
 
     private void executeMassAction(HttpServletRequest request, HttpServletResponse response,

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestOverviewWrapper.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestOverviewWrapper.java
@@ -34,7 +34,7 @@ public class ContestOverviewWrapper implements MassActionDataWrapper {
             new ContestFlagTextToolTipBean();
     private final ContestModelSettingsBean contestModelSettingsBean = new ContestModelSettingsBean();
 
-    private Long selectedMassAction;
+    private String selectedMassActionName;
     private Long memberId;
 
     @SuppressWarnings("unused")
@@ -113,12 +113,12 @@ public class ContestOverviewWrapper implements MassActionDataWrapper {
         this.memberId = memberId;
     }
 
-    public Long getSelectedMassAction() {
-        return selectedMassAction;
+    public String getSelectedMassAction() {
+        return selectedMassActionName;
     }
 
-    public void setSelectedMassAction(Long selectedMassAction) {
-        this.selectedMassAction = selectedMassAction;
+    public void setSelectedMassAction(String selectedMassAction) {
+        this.selectedMassActionName = selectedMassAction;
     }
 
     public Map<Long, Boolean> getSubscribedToContest() {

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestOverviewWrapper.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestOverviewWrapper.java
@@ -113,12 +113,12 @@ public class ContestOverviewWrapper implements MassActionDataWrapper {
         this.memberId = memberId;
     }
 
-    public String getSelectedMassAction() {
+    public String getSelectedMassActionName() {
         return selectedMassActionName;
     }
 
-    public void setSelectedMassAction(String selectedMassAction) {
-        this.selectedMassActionName = selectedMassAction;
+    public void setSelectedMassActionName(String selectedMassActionName) {
+        this.selectedMassActionName = selectedMassActionName;
     }
 
     public Map<Long, Boolean> getSubscribedToContest() {

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestOverviewWrapper.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestOverviewWrapper.java
@@ -13,7 +13,6 @@ import org.xcolab.util.http.client.RestService;
 import org.xcolab.view.pages.contestmanagement.beans.ContestFlagTextToolTipBean;
 import org.xcolab.view.pages.contestmanagement.beans.ContestModelSettingsBean;
 import org.xcolab.view.pages.contestmanagement.beans.MassMessageBean;
-import org.xcolab.view.pages.contestmanagement.entities.ContestMassAction;
 import org.xcolab.view.pages.contestmanagement.entities.ContestMassActions;
 import org.xcolab.view.pages.contestmanagement.entities.massactions.MassActionDataWrapper;
 
@@ -35,7 +34,7 @@ public class ContestOverviewWrapper implements MassActionDataWrapper {
             new ContestFlagTextToolTipBean();
     private final ContestModelSettingsBean contestModelSettingsBean = new ContestModelSettingsBean();
 
-    private String selectedMassActionName;
+    private ContestMassActions selectedMassAction;
     private Long memberId;
 
     @SuppressWarnings("unused")
@@ -114,16 +113,12 @@ public class ContestOverviewWrapper implements MassActionDataWrapper {
         this.memberId = memberId;
     }
 
-    public String getSelectedMassActionName() {
-        return selectedMassActionName;
+    public void setSelectedMassAction(ContestMassActions selectedMassAction) {
+        this.selectedMassAction = selectedMassAction;
     }
 
-    public ContestMassAction getSelectedMassAction() {
-        return ContestMassActions.valueOf(selectedMassActionName).getAction();
-    }
-
-    public void setSelectedMassActionName(String selectedMassActionName) {
-        this.selectedMassActionName = selectedMassActionName;
+    public ContestMassActions getSelectedMassAction() {
+        return selectedMassAction;
     }
 
     public Map<Long, Boolean> getSubscribedToContest() {

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestOverviewWrapper.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestOverviewWrapper.java
@@ -13,6 +13,7 @@ import org.xcolab.util.http.client.RestService;
 import org.xcolab.view.pages.contestmanagement.beans.ContestFlagTextToolTipBean;
 import org.xcolab.view.pages.contestmanagement.beans.ContestModelSettingsBean;
 import org.xcolab.view.pages.contestmanagement.beans.MassMessageBean;
+import org.xcolab.view.pages.contestmanagement.entities.ContestMassAction;
 import org.xcolab.view.pages.contestmanagement.entities.ContestMassActions;
 import org.xcolab.view.pages.contestmanagement.entities.massactions.MassActionDataWrapper;
 
@@ -115,6 +116,10 @@ public class ContestOverviewWrapper implements MassActionDataWrapper {
 
     public String getSelectedMassActionName() {
         return selectedMassActionName;
+    }
+
+    public ContestMassAction getSelectedMassAction() {
+        return ContestMassActions.valueOf(selectedMassActionName).getAction();
     }
 
     public void setSelectedMassActionName(String selectedMassActionName) {

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/MassActionConfirmationWrapper.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/MassActionConfirmationWrapper.java
@@ -18,7 +18,7 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
     private List<Contest> contestWrappers;
     private List<Long> contestIds;
     private List<Boolean> selectedContest;
-    private String selectedMassActionName;
+    private ContestMassActions selectedMassAction;
     private Integer itemCount;
     private Long memberId;
 
@@ -29,10 +29,10 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
     }
 
     public MassActionConfirmationWrapper(List<Long> contestIds,
-            ContestMassActions selectedMassActionWrapper) {
+            ContestMassActions selectedMassAction) {
         this.selectedContest = new ArrayList<>();
         this.contestWrappers = new ArrayList<>();
-        this.selectedMassActionName = selectedMassActionWrapper.name();
+        this.selectedMassAction= selectedMassAction;
         this.itemCount = contestIds.size();
         this.contestIds = contestIds;
         populateValidContestWrapper(contestIds);
@@ -82,12 +82,12 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
         this.itemCount = itemCount;
     }
 
-    public String getSelectedMassActionName() {
-        return selectedMassActionName;
+    public ContestMassActions getSelectedMassAction() {
+        return selectedMassAction;
     }
 
-    public void setSelectedMassActionName(String selectedMassActionName) {
-        this.selectedMassActionName = selectedMassActionName;
+    public void setSelectedMassAction(ContestMassActions selectedMassAction) {
+        this.selectedMassAction = selectedMassAction;
     }
 
     @Override
@@ -97,10 +97,6 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
 
     public void setMemberId(Long memberId) {
         this.memberId = memberId;
-    }
-
-    public ContestMassAction getSelectedMassAction() {
-        return ContestMassActions.valueOf(selectedMassActionName).getAction();
     }
 
     public List<Long> getSelectedContestIds() {

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/MassActionConfirmationWrapper.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/MassActionConfirmationWrapper.java
@@ -19,7 +19,6 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
     private List<Long> contestIds;
     private List<Boolean> selectedContest;
     private String selectedMassActionName;
-    private ContestMassAction selectedMassAction;
     private Integer itemCount;
     private Long memberId;
 
@@ -29,10 +28,11 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
         this.contestIds = new ArrayList<>();
     }
 
-    public MassActionConfirmationWrapper(List<Long> contestIds, String selectedMassActionName) {
+    public MassActionConfirmationWrapper(List<Long> contestIds,
+            ContestMassActions selectedMassActionWrapper) {
         this.selectedContest = new ArrayList<>();
         this.contestWrappers = new ArrayList<>();
-        this.setSelectedMassActionName(selectedMassActionName);
+        this.selectedMassActionName = selectedMassActionWrapper.name();
         this.itemCount = contestIds.size();
         this.contestIds = contestIds;
         populateValidContestWrapper(contestIds);
@@ -88,7 +88,6 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
 
     public void setSelectedMassActionName(String selectedMassActionName) {
         this.selectedMassActionName = selectedMassActionName;
-        this.selectedMassAction = ContestMassActions.valueOf(selectedMassActionName).getAction();
     }
 
     @Override
@@ -101,7 +100,7 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
     }
 
     public ContestMassAction getSelectedMassAction() {
-        return selectedMassAction;
+        return ContestMassActions.valueOf(selectedMassActionName).getAction();
     }
 
     public List<Long> getSelectedContestIds() {

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/MassActionConfirmationWrapper.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/MassActionConfirmationWrapper.java
@@ -18,7 +18,7 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
     private List<Contest> contestWrappers;
     private List<Long> contestIds;
     private List<Boolean> selectedContest;
-    private int massActionId;
+    private String massActionName;
     private ContestMassAction selectedMassAction;
     private Integer itemCount;
     private Long memberId;
@@ -29,10 +29,10 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
         this.contestIds = new ArrayList<>();
     }
 
-    public MassActionConfirmationWrapper(List<Long> contestIds, int massActionId) {
+    public MassActionConfirmationWrapper(List<Long> contestIds, String massActionName) {
         this.selectedContest = new ArrayList<>();
         this.contestWrappers = new ArrayList<>();
-        this.setMassActionId(massActionId);
+        this.setMassActionName(massActionName);
         this.itemCount = contestIds.size();
         this.contestIds = contestIds;
         populateValidContestWrapper(contestIds);
@@ -82,13 +82,13 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
         this.itemCount = itemCount;
     }
 
-    public Integer getMassActionId() {
-        return massActionId;
+    public String getMassActionName() {
+        return massActionName;
     }
 
-    public void setMassActionId(Integer massActionId) {
-        this.massActionId = massActionId;
-        this.selectedMassAction = ContestMassActions.values()[massActionId].getAction();
+    public void setMassActionName(String massActionName) {
+        this.massActionName = massActionName;
+        this.selectedMassAction = ContestMassActions.valueOf(massActionName).getAction();
     }
 
     @Override

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/MassActionConfirmationWrapper.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/MassActionConfirmationWrapper.java
@@ -18,7 +18,7 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
     private List<Contest> contestWrappers;
     private List<Long> contestIds;
     private List<Boolean> selectedContest;
-    private String massActionName;
+    private String selectedMassActionName;
     private ContestMassAction selectedMassAction;
     private Integer itemCount;
     private Long memberId;
@@ -29,10 +29,10 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
         this.contestIds = new ArrayList<>();
     }
 
-    public MassActionConfirmationWrapper(List<Long> contestIds, String massActionName) {
+    public MassActionConfirmationWrapper(List<Long> contestIds, String selectedMassActionName) {
         this.selectedContest = new ArrayList<>();
         this.contestWrappers = new ArrayList<>();
-        this.setMassActionName(massActionName);
+        this.setSelectedMassActionName(selectedMassActionName);
         this.itemCount = contestIds.size();
         this.contestIds = contestIds;
         populateValidContestWrapper(contestIds);
@@ -82,13 +82,13 @@ public class MassActionConfirmationWrapper implements MassActionDataWrapper {
         this.itemCount = itemCount;
     }
 
-    public String getMassActionName() {
-        return massActionName;
+    public String getSelectedMassActionName() {
+        return selectedMassActionName;
     }
 
-    public void setMassActionName(String massActionName) {
-        this.massActionName = massActionName;
-        this.selectedMassAction = ContestMassActions.valueOf(massActionName).getAction();
+    public void setSelectedMassActionName(String selectedMassActionName) {
+        this.selectedMassActionName = selectedMassActionName;
+        this.selectedMassAction = ContestMassActions.valueOf(selectedMassActionName).getAction();
     }
 
     @Override

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/massActionConfirmation/confirmMassAction.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/massActionConfirmation/confirmMassAction.jspx
@@ -47,7 +47,7 @@
                     </tr>
                     </thead>
                     <tbody id="contestOverviewBody">
-                    <form:hidden path="massActionName"/>
+                    <form:hidden path="selectedMassActionName"/>
                     <form:hidden path="itemCount"/>
                     <c:forEach var="contestWrapper" items="${massActionConfirmationWrapper.contestWrappers}"
                                varStatus="x">

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/massActionConfirmation/confirmMassAction.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/massActionConfirmation/confirmMassAction.jspx
@@ -16,7 +16,7 @@
                     <div class="proposal-title"><h1>Mass Action Confirmation</h1>
                         <span class="floatLeft clearLeft">
                     <h3>
-                    Please confirm the contest(s) that you want to execute the mass action "${massActionConfirmationWrapper.selectedMassAction.displayName}" on!
+                    Please confirm the contest(s) that you want to execute the mass action "${massActionConfirmationWrapper.selectedMassAction.action.displayName}" on!
                     </h3>
                 </span>
                     </div>
@@ -28,7 +28,7 @@
                    id="editForm" method="post">
             <div class="c-ContentBox">
                 <div class="outerVerticalCenter">
-                    <a class="c-Button__primary innerVerticalCenter" href="#" id="submitButton">${massActionConfirmationWrapper.selectedMassAction.displayName}</a>
+                    <a class="c-Button__primary innerVerticalCenter" href="#" id="submitButton">${massActionConfirmationWrapper.selectedMassAction.action.displayName}</a>
                     <a class="c-Button__secondary innerVerticalCenter" href="/admin/contest/manager">DISCARD &amp; go back to overview</a>
                 </div>
             </div>
@@ -47,7 +47,7 @@
                     </tr>
                     </thead>
                     <tbody id="contestOverviewBody">
-                    <form:hidden path="selectedMassActionName"/>
+                    <form:hidden path="selectedMassAction"/>
                     <form:hidden path="itemCount"/>
                     <c:forEach var="contestWrapper" items="${massActionConfirmationWrapper.contestWrappers}"
                                varStatus="x">

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/massActionConfirmation/confirmMassAction.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/massActionConfirmation/confirmMassAction.jspx
@@ -47,7 +47,7 @@
                     </tr>
                     </thead>
                     <tbody id="contestOverviewBody">
-                    <form:hidden path="massActionId"/>
+                    <form:hidden path="massActionName"/>
                     <form:hidden path="itemCount"/>
                     <c:forEach var="contestWrapper" items="${massActionConfirmationWrapper.contestWrappers}"
                                varStatus="x">

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
@@ -44,7 +44,7 @@
 		<form:form action="/admin/contest/manager/update" modelAttribute="contestOverviewWrapper" id="editForm" method="post">
 			<div class="outerVerticalCenter">
 				<div class="innerVerticalCenter">
-					<form:select path="selectedMassActionName" id="selectedMassAction" cssClass="form-control">
+					<form:select path="selectedMassAction" id="selectedMassAction" cssClass="form-control">
 						<form:options items="${massActionsItems}" />
 					</form:select>
 				</div>

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
@@ -44,7 +44,7 @@
 		<form:form action="/admin/contest/manager/update" modelAttribute="contestOverviewWrapper" id="editForm" method="post">
 			<div class="outerVerticalCenter">
 				<div class="innerVerticalCenter">
-					<form:select path="selectedMassAction" id="selectedMassAction" cssClass="form-control">
+					<form:select path="selectedMassActionName" id="selectedMassAction" cssClass="form-control">
 						<form:options items="${massActionsItems}" />
 					</form:select>
 				</div>

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/overviewTab.jspx
@@ -6,7 +6,7 @@
 
 <jsp:directive.page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"/>
 <xcolab:layout>
-    <!--@elvariable id="massActionsItems" type="java.util.List<org.xcolab.util.html.LabelValue>"-->
+    <!--@elvariable id="massActionsItems" type="java.util.Map<String, String>"-->
 	<!--@elvariable id="contestOverviewWrapper" type="org.xcolab.view.pages.contestmanagement.wrappers.ContestOverviewWrapper"-->
 
 	<jsp:directive.include file="../init.jspx" />
@@ -45,7 +45,7 @@
 			<div class="outerVerticalCenter">
 				<div class="innerVerticalCenter">
 					<form:select path="selectedMassAction" id="selectedMassAction" cssClass="form-control">
-						<form:options items="${massActionsItems}" itemValue="value" itemLabel="lable"/>
+						<form:options items="${massActionsItems}" />
 					</form:select>
 				</div>
 				<a class="c-Button__primary innerVerticalCenter" href="#" id="submitButton">SUBMIT</a>


### PR DESCRIPTION
This PR changes a mapping of the mass action select dropdown to the selected mass action class from the mass action index to the mass action name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/34)
<!-- Reviewable:end -->
