### PR TITLE
COLAB-2255 Contest widget default image

### DIFF
--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
@@ -52,7 +52,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 public class Contest extends AbstractContest implements Serializable {
 
@@ -190,26 +189,20 @@ public class Contest extends AbstractContest implements Serializable {
             return "";
         }
     }
+
     public String getCleanContestDescription() {
         return HtmlUtil.cleanAll(this.getContestDescription());
     }
-    public String getLogoPath() {
-        if (this.getIsSharedContestInForeignColab()) {
 
-            Long imgId = this.getContestLogoId();
-            if (imgId != null) {
-                return ConfigurationAttributeKey.PARTNER_COLAB_ADDRESS.get()
-                        + "/image/contest/" + imgId;
-            }
-            return "";
+    public String getLogoPath() {
+        long imgId = this.getContestLogoId() != null ? this.getContestLogoId() : 0;
+        String imageDomain;
+        if (this.getIsSharedContestInForeignColab()) {
+            imageDomain = ConfigurationAttributeKey.PARTNER_COLAB_ADDRESS.get();
         } else {
-            Long imgId = this.getContestLogoId();
-            if (imgId != null) {
-                final String imageDomain = PlatformAttributeKey.IMAGES_UPLOADED_DOMAIN.get();
-                return imageDomain + "/image/contest/" + imgId;
-            }
-            return "";
+            imageDomain = PlatformAttributeKey.IMAGES_UPLOADED_DOMAIN.get();
         }
+        return imageDomain + "/image/contest/" + imgId;
     }
 
     public boolean getShowInTileView(){

--- a/view/src/main/webapp/WEB-INF/jsp/widgets/contests/showContests.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/widgets/contests/showContests.jspx
@@ -15,14 +15,7 @@
             <div class="c-ContestBox backgroundLight">
                 <div class="c-ContestBox__image">
                     <a href="${contest.contestUrl}">
-                        <c:choose>
-                            <c:when test="${contest.contestLogoId > 0}">
-                                <img src="${contest.logoPath}" width="151" height="151" alt="${contest.contestShortName}" />
-                            </c:when>
-                            <c:otherwise>
-                                <img src="${_themeImageFolder}/blank.gif" width="151" height="151" alt="${contest.contestShortName}" style="border: 1px solid #bbb;"/>
-                            </c:otherwise>
-                        </c:choose>
+                        <img src="${contest.logoPath}" width="151" height="151" alt="${contest.contestShortName}" />
                     </a>
                 </div>
                 <div class="c-ContestBox__text">


### PR DESCRIPTION
This pull requests fixes a display issue when a contest shown in the contest widget has no image set. Previously, it would show a broken placeholder image; now it shows the default contest image (as it would in other places on the site).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/36)
<!-- Reviewable:end -->
