### PR TITLE
COLAB-2259 Refactoring image urls and error handling

### DIFF
--- a/microservices/clients/files-client/src/main/java/org/xcolab/client/files/FilesClient.java
+++ b/microservices/clients/files-client/src/main/java/org/xcolab/client/files/FilesClient.java
@@ -37,12 +37,14 @@ public final class FilesClient {
     }
 
     public static Optional<FileEntry> getFileEntry(Long fileEntryId) {
-        try {
-            return Optional.of(fileEntryResource.get(fileEntryId)
-                    .withCache(CacheKeys.of(FileEntry.class, fileEntryId), CacheName.MISC_LONG)
-                    .executeChecked());
-        } catch (EntityNotFoundException e) {
-            return Optional.empty();
+        if (fileEntryId != null && fileEntryId > 0) {
+            try {
+                return Optional.of(fileEntryResource.get(fileEntryId)
+                        .withCache(CacheKeys.of(FileEntry.class, fileEntryId), CacheName.MISC_LONG)
+                        .executeChecked());
+            } catch (EntityNotFoundException ignored) {
+            }
         }
+        return Optional.empty();
     }
 }

--- a/view/src/main/java/org/xcolab/view/config/spring/beans/WebConfig.java
+++ b/view/src/main/java/org/xcolab/view/config/spring/beans/WebConfig.java
@@ -13,6 +13,7 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.http.CacheControl;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.util.Assert;
@@ -29,6 +30,7 @@ import org.springframework.web.servlet.resource.VersionResourceResolver;
 
 import org.xcolab.view.auth.AuthenticationContext;
 import org.xcolab.view.config.rewrite.RewriteInitializer;
+import org.xcolab.view.config.spring.converters.CaseInsensitiveStringToEnumConverterFactory;
 import org.xcolab.view.config.spring.properties.ServerProperties;
 import org.xcolab.view.config.spring.properties.TomcatProperties;
 import org.xcolab.view.config.spring.properties.WebProperties;
@@ -98,6 +100,11 @@ public class WebConfig extends WebMvcConfigurerAdapter {
         registry.addInterceptor(populateContextInterceptor).addPathPatterns("/contests/**");
         registry.addInterceptor(validateTabPermissionsInterceptor).addPathPatterns("/contests/**");
         registry.addInterceptor(localeChangeInterceptor());
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverterFactory(new CaseInsensitiveStringToEnumConverterFactory());
     }
 
     private LocaleChangeInterceptor localeChangeInterceptor() {

--- a/view/src/main/java/org/xcolab/view/config/spring/converters/CaseInsensitiveStringToEnumConverterFactory.java
+++ b/view/src/main/java/org/xcolab/view/config/spring/converters/CaseInsensitiveStringToEnumConverterFactory.java
@@ -1,0 +1,50 @@
+package org.xcolab.view.config.spring.converters;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.ConverterFactory;
+
+/**
+ * Converter to support converting lower case enum names to enums.
+ *
+ * Adapted from {@link org.springframework.core.convert.support.StringToEnumConverterFactory}.
+ */
+public final class CaseInsensitiveStringToEnumConverterFactory
+        implements ConverterFactory<String, Enum> {
+
+    @Override
+    public <T extends Enum> Converter<String, T> getConverter(Class<T> targetType) {
+        //noinspection unchecked
+        return new StringToEnum(getEnumType(targetType));
+    }
+
+    private Class<?> getEnumType(Class<?> targetType) {
+        Class<?> enumType = targetType;
+        while (enumType != null && !enumType.isEnum()) {
+            enumType = enumType.getSuperclass();
+        }
+        if (enumType == null) {
+            throw new IllegalArgumentException(
+                    "The target type " + targetType.getName() + " does not refer to an enum");
+        }
+        return enumType;
+    }
+
+    private static class StringToEnum<T extends Enum> implements Converter<String, T> {
+
+        private final Class<T> enumType;
+
+        public StringToEnum(Class<T> enumType) {
+            this.enumType = enumType;
+        }
+
+        @Override
+        public T convert(String source) {
+            if (source.isEmpty()) {
+                return null;
+            }
+            //noinspection unchecked
+            return (T) Enum.valueOf(this.enumType, source.trim().toUpperCase());
+        }
+    }
+
+}

--- a/view/src/main/java/org/xcolab/view/files/DefaultImage.java
+++ b/view/src/main/java/org/xcolab/view/files/DefaultImage.java
@@ -1,0 +1,18 @@
+package org.xcolab.view.files;
+
+public enum DefaultImage {
+    NONE(""),
+    MEMBER("/images/user_default.png"),
+    PROPOSAL("/images/proposal_default.png"),
+    CONTEST("/images/proposal_default.png");
+
+    private final String imagePath;
+
+    DefaultImage(String imagePath) {
+        this.imagePath = imagePath;
+    }
+
+    public String getImagePath() {
+        return imagePath;
+    }
+}

--- a/view/src/main/java/org/xcolab/view/files/ImageDisplayController.java
+++ b/view/src/main/java/org/xcolab/view/files/ImageDisplayController.java
@@ -1,71 +1,69 @@
 package org.xcolab.view.files;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.CacheControl;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import org.xcolab.client.admin.attributes.configuration.ConfigurationAttributeKey;
-import org.xcolab.client.admin.attributes.platform.PlatformAttributeKey;
-import org.xcolab.client.admin.enums.ServerEnvironment;
 import org.xcolab.client.contest.ContestClientUtil;
+import org.xcolab.client.contest.exceptions.ContestNotFoundException;
 import org.xcolab.client.contest.pojo.Contest;
-import org.xcolab.client.files.FilesClient;
-import org.xcolab.client.files.pojo.FileEntry;
 import org.xcolab.client.members.MembersClient;
+import org.xcolab.client.members.exceptions.MemberNotFoundException;
 import org.xcolab.client.members.pojo.Member;
 import org.xcolab.client.proposals.ProposalClientUtil;
+import org.xcolab.client.proposals.exceptions.ProposalNotFoundException;
 import org.xcolab.client.proposals.pojo.Proposal;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
-import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Controller
 public class ImageDisplayController {
 
-    private static final Logger log = LoggerFactory.getLogger(ImageDisplayController.class);
+    private final ImageDisplayService imageDisplayService;
 
-    private final boolean isProduction;
-    private final String basePath = PlatformAttributeKey.FILES_UPLOAD_DIR.get();
-
-    public ImageDisplayController() {
-        final ServerEnvironment serverEnvironment =
-                PlatformAttributeKey.SERVER_ENVIRONMENT.get();
-        isProduction = serverEnvironment == ServerEnvironment.PRODUCTION;
+    public ImageDisplayController(ImageDisplayService imageDisplayService) {
+        this.imageDisplayService = imageDisplayService;
     }
 
     @GetMapping("/image/contests/{contestId}")
     public void serveContestImage(HttpServletRequest request, HttpServletResponse response,
             @PathVariable long contestId) throws IOException {
-        Contest contest = ContestClientUtil.getContest(contestId);
-        serveImage(request, response, contest.getContestLogoId(), DefaultImage.CONTEST);
+        try {
+            Contest contest = ContestClientUtil.getContest(contestId);
+            imageDisplayService.serveImage(request, response,
+                    contest.getContestLogoId(), DefaultImage.CONTEST);
+        } catch (ContestNotFoundException e) {
+            response.sendError(HttpStatus.NOT_FOUND.value(), "Contest not found.");
+        }
     }
 
     @GetMapping("/image/proposals/{proposalId}")
     public void serveProposalImage(HttpServletRequest request, HttpServletResponse response,
             @PathVariable long proposalId) throws IOException {
-        Proposal proposal = ProposalClientUtil.getProposal(proposalId);
-        serveImage(request, response, proposal.getImageId(), DefaultImage.PROPOSAL);
+        try {
+            Proposal proposal = ProposalClientUtil.getProposal(proposalId);
+            imageDisplayService.serveImage(request, response,
+                    proposal.getImageId(), DefaultImage.PROPOSAL);
+        } catch (ProposalNotFoundException e) {
+            response.sendError(HttpStatus.NOT_FOUND.value(), "Proposal not found.");
+        }
     }
 
     @GetMapping("/image/members/{memberId}")
     public void serveMemberImage(HttpServletRequest request, HttpServletResponse response,
             @PathVariable long memberId) throws IOException {
-        Member member = MembersClient.getMemberUnchecked(memberId);
-        serveImage(request, response, member.getPortraitId(), DefaultImage.PROPOSAL);
+        try {
+            Member member = MembersClient.getMember(memberId);
+            imageDisplayService.serveImage(request, response,
+                    member.getPortraitId(), DefaultImage.PROPOSAL);
+        } catch (MemberNotFoundException e) {
+            response.sendError(HttpStatus.NOT_FOUND.value(), "Member not found.");
+        }
     }
 
     @GetMapping("/image/uploaded/{imageId}")
@@ -73,138 +71,7 @@ public class ImageDisplayController {
             HttpServletResponse response, @PathVariable long imageId,
             @RequestParam(defaultValue = "NONE") DefaultImage defaultImage) throws IOException {
 
-        if (imageId > 0) {
-            final Optional<FileEntry> fileEntryOpt = FilesClient.getFileEntry(imageId);
-            if (fileEntryOpt.isPresent()) {
-                FileEntry fileEntry = fileEntryOpt.get();
-                File imageFile = fileEntry.getImageFile(basePath);
-                if (imageFile != null) {
-                    final boolean success = sendImageToResponse(request, response, imageFile);
-                    if (success) {
-                        return;
-                    }
-                } else if (!isProduction) {
-                    String newURL = ConfigurationAttributeKey.COLAB_URL_PRODUCTION.get()
-                            + request.getRequestURI() + "?" + request.getQueryString();
-
-                    response.sendRedirect(newURL);
-                    return;
-                }
-            }
-        }
-
-        if (!defaultImage.equals(DefaultImage.NONE)) {
-            response.sendRedirect(defaultImage.getImagePath());
-            return;
-        }
-        response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        imageDisplayService.serveImage(request, response, imageId, defaultImage);
     }
 
-    @GetMapping("/image/contest/{imageId}")
-    @Deprecated
-    public void serveContestImageLegacy(HttpServletRequest request, HttpServletResponse response,
-            @PathVariable long imageId) throws IOException {
-        serveImage(request, response, imageId, DefaultImage.CONTEST);
-    }
-
-    @GetMapping("/image/proposal/{imageId}")
-    @Deprecated
-    public void serveProposalImageLegacy(HttpServletRequest request, HttpServletResponse response,
-            @PathVariable long imageId) throws IOException {
-        serveImage(request, response, imageId, DefaultImage.PROPOSAL);
-    }
-
-    @GetMapping("/image/member/{imageId}")
-    @Deprecated
-    public void serveMemberImageLegacy(HttpServletRequest request, HttpServletResponse response,
-            @PathVariable long imageId) throws IOException {
-        serveImage(request, response, imageId, DefaultImage.MEMBER);
-    }
-
-    @GetMapping({"/image/{whatever}", "/image"})
-    public void serveImageLegacy(HttpServletRequest request, HttpServletResponse response,
-            @RequestParam(value = "img_id", required = false) Long imgId,
-            @RequestParam(required = false) Long portraitId,
-            @RequestParam(required = false) Long userId,
-            @RequestParam(required = false, defaultValue = "NONE") DefaultImage defaultImage)
-            throws IOException {
-
-        if (userId != null) {
-            serveMemberImage(request, response, userId);
-            return;
-        }
-
-        Long imageId = null;
-        if (imgId != null) {
-            imageId = imgId;
-        }
-
-        if (imageId == null) {
-            if (portraitId != null) {
-                imageId = portraitId;
-            } else {
-                imageId = 0L;
-            }
-        }
-
-        if (request.getRequestURI().contains("user_male_portrait")) {
-            defaultImage = DefaultImage.MEMBER;
-        }
-
-        serveImage(request, response, imageId, defaultImage);
-    }
-
-    private boolean sendImageToResponse(HttpServletRequest request, HttpServletResponse response,
-            File imageFile) {
-
-        try {
-            ServletContext servletContext = request.getSession().getServletContext();
-            String mime = servletContext.getMimeType(imageFile.getAbsolutePath());
-            if (mime == null) {
-                log.error("Could not retrieve mime typ for image {}", imageFile.getAbsolutePath());
-                return false;
-            }
-
-            response.setContentType(mime);
-            response.setContentLength((int) imageFile.length());
-
-            FileInputStream in = new FileInputStream(imageFile);
-            OutputStream out = response.getOutputStream();
-
-            // Copy the contents of the file to the output stream
-            byte[] buf = new byte[1024];
-            int count;
-            while ((count = in.read(buf)) >= 0) {
-                out.write(buf, 0, count);
-            }
-            out.close();
-            in.close();
-            response.setHeader(HttpHeaders.CACHE_CONTROL,
-                    CacheControl.maxAge(7, TimeUnit.DAYS)
-                            .staleWhileRevalidate(90, TimeUnit.DAYS)
-                            .getHeaderValue());
-            return true;
-        } catch (IOException e) {
-            log.error("Error while sending image {} to response: {}",
-                    imageFile.getAbsolutePath(), e.getMessage());
-            return false;
-        }
-    }
-
-    public enum DefaultImage {
-        NONE(""),
-        MEMBER("/images/user_default.png"),
-        PROPOSAL("/images/proposal_default.png"),
-        CONTEST("/images/proposal_default.png");
-
-        private final String imagePath;
-
-        DefaultImage(String imagePath) {
-            this.imagePath = imagePath;
-        }
-
-        public String getImagePath() {
-            return imagePath;
-        }
-    }
 }

--- a/view/src/main/java/org/xcolab/view/files/ImageDisplayController.java
+++ b/view/src/main/java/org/xcolab/view/files/ImageDisplayController.java
@@ -1,20 +1,8 @@
 package org.xcolab.view.files;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-
-import org.xcolab.client.contest.ContestClientUtil;
-import org.xcolab.client.contest.exceptions.ContestNotFoundException;
-import org.xcolab.client.contest.pojo.Contest;
-import org.xcolab.client.members.MembersClient;
-import org.xcolab.client.members.exceptions.MemberNotFoundException;
-import org.xcolab.client.members.pojo.Member;
-import org.xcolab.client.proposals.ProposalClientUtil;
-import org.xcolab.client.proposals.exceptions.ProposalNotFoundException;
-import org.xcolab.client.proposals.pojo.Proposal;
 
 import java.io.IOException;
 
@@ -30,48 +18,17 @@ public class ImageDisplayController {
         this.imageDisplayService = imageDisplayService;
     }
 
-    @GetMapping("/image/contests/{contestId}")
-    public void serveContestImage(HttpServletRequest request, HttpServletResponse response,
-            @PathVariable long contestId) throws IOException {
-        try {
-            Contest contest = ContestClientUtil.getContest(contestId);
-            imageDisplayService.serveImage(request, response,
-                    contest.getContestLogoId(), DefaultImage.CONTEST);
-        } catch (ContestNotFoundException e) {
-            response.sendError(HttpStatus.NOT_FOUND.value(), "Contest not found.");
-        }
+    @GetMapping("/image/upload/images/{imageId}")
+    public void serveImage(HttpServletRequest request, HttpServletResponse response,
+            @PathVariable long imageId)
+            throws IOException {
+        imageDisplayService.serveImage(request, response, imageId, ImageType.UNKNOWN);
     }
 
-    @GetMapping("/image/proposals/{proposalId}")
-    public void serveProposalImage(HttpServletRequest request, HttpServletResponse response,
-            @PathVariable long proposalId) throws IOException {
-        try {
-            Proposal proposal = ProposalClientUtil.getProposal(proposalId);
-            imageDisplayService.serveImage(request, response,
-                    proposal.getImageId(), DefaultImage.PROPOSAL);
-        } catch (ProposalNotFoundException e) {
-            response.sendError(HttpStatus.NOT_FOUND.value(), "Proposal not found.");
-        }
+    @GetMapping("/image/upload/{imageType}/images/{imageId}")
+    public void serveImage(HttpServletRequest request, HttpServletResponse response,
+            @PathVariable long imageId, @PathVariable ImageType imageType)
+            throws IOException {
+        imageDisplayService.serveImage(request, response, imageId, imageType);
     }
-
-    @GetMapping("/image/members/{memberId}")
-    public void serveMemberImage(HttpServletRequest request, HttpServletResponse response,
-            @PathVariable long memberId) throws IOException {
-        try {
-            Member member = MembersClient.getMember(memberId);
-            imageDisplayService.serveImage(request, response,
-                    member.getPortraitId(), DefaultImage.PROPOSAL);
-        } catch (MemberNotFoundException e) {
-            response.sendError(HttpStatus.NOT_FOUND.value(), "Member not found.");
-        }
-    }
-
-    @GetMapping("/image/uploaded/{imageId}")
-    public void serveImage(HttpServletRequest request,
-            HttpServletResponse response, @PathVariable long imageId,
-            @RequestParam(defaultValue = "NONE") DefaultImage defaultImage) throws IOException {
-
-        imageDisplayService.serveImage(request, response, imageId, defaultImage);
-    }
-
 }

--- a/view/src/main/java/org/xcolab/view/files/ImageDisplayService.java
+++ b/view/src/main/java/org/xcolab/view/files/ImageDisplayService.java
@@ -1,0 +1,119 @@
+package org.xcolab.view.files;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import org.xcolab.client.admin.attributes.configuration.ConfigurationAttributeKey;
+import org.xcolab.client.admin.attributes.platform.PlatformAttributeKey;
+import org.xcolab.client.admin.enums.ServerEnvironment;
+import org.xcolab.client.files.FilesClient;
+import org.xcolab.client.files.pojo.FileEntry;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Service
+public class ImageDisplayService {
+
+    private static final Logger log = LoggerFactory.getLogger(ImageDisplayService.class);
+
+    private final boolean isProduction;
+    private final String basePath = PlatformAttributeKey.FILES_UPLOAD_DIR.get();
+
+    public ImageDisplayService() {
+        final ServerEnvironment serverEnvironment =
+                PlatformAttributeKey.SERVER_ENVIRONMENT.get();
+        isProduction = serverEnvironment == ServerEnvironment.PRODUCTION;
+    }
+
+    public void serveImage(HttpServletRequest request, HttpServletResponse response,
+            @PathVariable long imageId,
+            @RequestParam(defaultValue = "NONE") DefaultImage defaultImage) throws IOException {
+
+        final Optional<FileEntry> fileEntryOpt = FilesClient.getFileEntry(imageId);
+        if (fileEntryOpt.isPresent()) {
+            FileEntry fileEntry = fileEntryOpt.get();
+            File imageFile = fileEntry.getImageFile(basePath);
+            final boolean success = sendImageToResponse(request, response, imageFile);
+            if (!success) {
+                if (isProduction) {
+                    if (!defaultImage.equals(DefaultImage.NONE)) {
+                        response.sendRedirect(defaultImage.getImagePath());
+                    } else {
+                        response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value());
+                    }
+                } else {
+                    forwardToImageOnProduction(request, response);
+                }
+            }
+        } else if (!defaultImage.equals(DefaultImage.NONE)) {
+            response.sendRedirect(defaultImage.getImagePath());
+        } else {
+            response.sendError(HttpStatus.NOT_FOUND.value(), "Image not found.");
+        }
+    }
+
+    private void forwardToImageOnProduction(HttpServletRequest request,
+            HttpServletResponse response) throws IOException {
+        String newURL = ConfigurationAttributeKey.COLAB_URL_PRODUCTION.get()
+                + request.getRequestURI() + "?" + request.getQueryString();
+
+        response.sendRedirect(newURL);
+    }
+
+    private boolean sendImageToResponse(HttpServletRequest request, HttpServletResponse response,
+            File imageFile) {
+
+        if (imageFile == null) {
+            return false;
+        }
+
+        try {
+            ServletContext servletContext = request.getSession().getServletContext();
+            String mime = servletContext.getMimeType(imageFile.getAbsolutePath());
+            if (mime == null) {
+                log.error("Could not retrieve mime typ for image {}", imageFile.getAbsolutePath());
+                return false;
+            }
+
+            response.setContentType(mime);
+            response.setContentLength((int) imageFile.length());
+
+            FileInputStream in = new FileInputStream(imageFile);
+            OutputStream out = response.getOutputStream();
+
+            // Copy the contents of the file to the output stream
+            byte[] buf = new byte[1024];
+            int count;
+            while ((count = in.read(buf)) >= 0) {
+                out.write(buf, 0, count);
+            }
+            out.close();
+            in.close();
+            response.setHeader(HttpHeaders.CACHE_CONTROL,
+                    CacheControl.maxAge(7, TimeUnit.DAYS)
+                            .staleWhileRevalidate(90, TimeUnit.DAYS)
+                            .getHeaderValue());
+            return true;
+        } catch (IOException e) {
+            log.error("Error while sending image {} to response: {}",
+                    imageFile.getAbsolutePath(), e.getMessage());
+            return false;
+        }
+    }
+
+}

--- a/view/src/main/java/org/xcolab/view/files/ImageDisplayService.java
+++ b/view/src/main/java/org/xcolab/view/files/ImageDisplayService.java
@@ -50,16 +50,20 @@ public class ImageDisplayService {
             File imageFile = fileEntry.getImageFile(BASE_PATH);
             final boolean success = sendImageToResponse(request, response, imageFile);
             if (success) {
-                response.setHeader(HttpHeaders.CACHE_CONTROL,
-                        CacheControl.maxAge(IMAGE_CACHE_MAX_AGE_DAYS, TimeUnit.DAYS)
-                                .staleWhileRevalidate(IMAGE_CACHE_STALE_DAYS, TimeUnit.DAYS)
-                                .getHeaderValue());
+                setCacheControlHeader(response);
             } else {
                 handleImageNotFoundError(request, response, imageType);
             }
         } else {
             handleFileEntryNotFoundError(request, response, imageId, imageType);
         }
+    }
+
+    private void setCacheControlHeader(HttpServletResponse response) {
+        response.setHeader(HttpHeaders.CACHE_CONTROL,
+                CacheControl.maxAge(IMAGE_CACHE_MAX_AGE_DAYS, TimeUnit.DAYS)
+                        .staleWhileRevalidate(IMAGE_CACHE_STALE_DAYS, TimeUnit.DAYS)
+                        .getHeaderValue());
     }
 
     private void handleImageNotFoundError(HttpServletRequest request, HttpServletResponse response,

--- a/view/src/main/java/org/xcolab/view/files/ImageType.java
+++ b/view/src/main/java/org/xcolab/view/files/ImageType.java
@@ -1,14 +1,14 @@
 package org.xcolab.view.files;
 
-public enum DefaultImage {
-    NONE(""),
+public enum ImageType {
+    UNKNOWN(""),
     MEMBER("/images/user_default.png"),
     PROPOSAL("/images/proposal_default.png"),
     CONTEST("/images/proposal_default.png");
 
     private final String imagePath;
 
-    DefaultImage(String imagePath) {
+    ImageType(String imagePath) {
         this.imagePath = imagePath;
     }
 

--- a/view/src/main/java/org/xcolab/view/files/LegacyImageDisplayController.java
+++ b/view/src/main/java/org/xcolab/view/files/LegacyImageDisplayController.java
@@ -1,0 +1,71 @@
+package org.xcolab.view.files;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Controller
+public class LegacyImageDisplayController {
+
+    private final ImageDisplayService imageDisplayService;
+    private final ImageDisplayController imageDisplayController;
+
+    public LegacyImageDisplayController(ImageDisplayService imageDisplayService,
+            ImageDisplayController imageDisplayController) {
+        this.imageDisplayService = imageDisplayService;
+        this.imageDisplayController = imageDisplayController;
+    }
+
+    @GetMapping("/image/contest/{imageId}")
+    public void serveContestImageLegacy(HttpServletRequest request, HttpServletResponse response,
+            @PathVariable long imageId) throws IOException {
+        imageDisplayService.serveImage(request, response, imageId, DefaultImage.CONTEST);
+    }
+
+    @GetMapping("/image/proposal/{imageId}")
+    public void serveProposalImageLegacy(HttpServletRequest request, HttpServletResponse response,
+            @PathVariable long imageId) throws IOException {
+        imageDisplayService.serveImage(request, response, imageId, DefaultImage.PROPOSAL);
+    }
+
+    @GetMapping("/image/member/{imageId}")
+    public void serveMemberImageLegacy(HttpServletRequest request, HttpServletResponse response,
+            @PathVariable long imageId) throws IOException {
+        imageDisplayService.serveImage(request, response, imageId, DefaultImage.MEMBER);
+    }
+
+    @GetMapping({"/image/{whatever}", "/image"})
+    public void serveImageLegacy(HttpServletRequest request, HttpServletResponse response,
+            @RequestParam(value = "img_id", required = false) Long imgId,
+            @RequestParam(required = false) Long portraitId,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false, defaultValue = "NONE") DefaultImage defaultImage)
+            throws IOException {
+
+        if (userId != null) {
+            imageDisplayController.serveMemberImage(request, response, userId);
+            return;
+        }
+
+        final Long imageId;
+        if (imgId != null) {
+            imageId = imgId;
+        } else if (portraitId != null) {
+            imageId = portraitId;
+        } else {
+            imageId = 0L;
+        }
+
+        if (request.getRequestURI().contains("user_male_portrait")) {
+            defaultImage = DefaultImage.MEMBER;
+        }
+
+        imageDisplayService.serveImage(request, response, imageId, defaultImage);
+    }
+}

--- a/view/src/main/java/org/xcolab/view/util/io/ServletFileUtil.java
+++ b/view/src/main/java/org/xcolab/view/util/io/ServletFileUtil.java
@@ -1,0 +1,36 @@
+package org.xcolab.view.util.io;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public final class ServletFileUtil {
+
+    private ServletFileUtil() {
+    }
+
+    public static String resolveMimeType(HttpServletRequest request, File file) throws IOException {
+        final ServletContext servletContext = request.getServletContext();
+        final String mimeType = servletContext.getMimeType(file.getAbsolutePath());
+        if (mimeType == null) {
+            throw new IOException("Cannot resolve mime type for file " + file.getAbsolutePath());
+        }
+        return mimeType;
+    }
+
+    public static void sendFileToResponse(HttpServletResponse response, File imageFile,
+            String mimeType) throws IOException {
+        response.setContentType(mimeType);
+
+        try (FileInputStream in = new FileInputStream(imageFile)) {
+            final int count = IOUtils.copy(in, response.getOutputStream());
+            response.setContentLength(count);
+        }
+    }
+}


### PR DESCRIPTION
This pull request refactors the `ImageDisplayController`. It has several goals:
* reduce ambiguity of image urls (current mappings don't make it clear if the `imageId` or `contestId` should be passed)
* improve delivery and caching of default images by avoiding browser redirects
* improve error handling to make it more robust (fallback to default images) and less misleading (correct status codes)
* improve readability of code by extracting methods and classes

Legacy URL mappings are preserved in a separate controller for backwards compatibility. Controllers will continue to use the deprecated mappings for the time being to ensure a smooth transition with respect to test servers.