### PR TITLE
COLAB-2253 Add fields to judging CSV

### DIFF
--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
@@ -94,15 +94,6 @@ public class Contest extends AbstractContest implements Serializable {
 
     private RestService restService;
 
-    public Contest(Long contestId) {
-        contestClient = ContestClientUtil.getClient();
-        contestTeamMemberClient = ContestTeamMemberClientUtil.getClient();
-        ontologyClient = OntologyClientUtil.getClient();
-        planTemplateClient = PlanTemplateClientUtil.getClient();
-        commentClient = CommentClientUtil.getClient();
-        threadClient = ThreadClientUtil.getClient();
-    }
-
     public Contest() {
         contestClient = ContestClientUtil.getClient();
         contestTeamMemberClient = ContestTeamMemberClientUtil.getClient();
@@ -113,8 +104,12 @@ public class Contest extends AbstractContest implements Serializable {
     }
 
     public Contest(Contest value) {
+        this(value, value.getRestService());
+    }
+
+    public Contest(AbstractContest value, RestService restService) {
         super(value);
-        if (value.getRestService() != null) {
+        if (restService != null) {
             contestClient = ContestClient.fromService(restService);
             contestTeamMemberClient = ContestTeamMemberClient.fromService(restService);
             ontologyClient = OntologyClient.fromService(restService);
@@ -130,18 +125,7 @@ public class Contest extends AbstractContest implements Serializable {
             commentClient = CommentClientUtil.getClient();
             threadClient = ThreadClientUtil.getClient();
         }
-    }
-
-    public Contest(AbstractContest abstractContest, RestService restService) {
-        super(abstractContest);
         this.restService = restService;
-        contestClient = ContestClient.fromService(this.restService);
-        contestTeamMemberClient = ContestTeamMemberClient.fromService(this.restService);
-        ontologyClient = OntologyClient.fromService(this.restService);
-        planTemplateClient = PlanTemplateClient.fromService(this.restService);
-        RestService commentService =  restService.withServiceName(CoLabService.COMMENT.getServiceName());
-        commentClient = CommentClient.fromService(commentService);
-        threadClient = ThreadClient.fromService(commentService);
     }
 
     public String getContestDiscussionLinkUrl() {

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/Contest.java
@@ -17,6 +17,8 @@ import org.xcolab.client.contest.ContestTeamMemberClient;
 import org.xcolab.client.contest.ContestTeamMemberClientUtil;
 import org.xcolab.client.contest.OntologyClient;
 import org.xcolab.client.contest.OntologyClientUtil;
+import org.xcolab.client.contest.PlanTemplateClient;
+import org.xcolab.client.contest.PlanTemplateClientUtil;
 import org.xcolab.client.contest.enums.ContestRole;
 import org.xcolab.client.contest.enums.ContestStatus;
 import org.xcolab.client.contest.pojo.ontology.FocusArea;
@@ -25,6 +27,7 @@ import org.xcolab.client.contest.pojo.phases.ContestPhase;
 import org.xcolab.client.contest.pojo.phases.ContestPhaseType;
 import org.xcolab.client.contest.pojo.team.ContestTeamMember;
 import org.xcolab.client.contest.pojo.team.ContestTeamMemberRole;
+import org.xcolab.client.contest.pojo.templates.PlanSectionDefinition;
 import org.xcolab.client.contest.util.ContestScheduleChangeHelper;
 import org.xcolab.client.members.MembersClient;
 import org.xcolab.client.members.exceptions.MemberNotFoundException;
@@ -62,6 +65,7 @@ public class Contest extends AbstractContest implements Serializable {
     private final OntologyClient ontologyClient;
     private final CommentClient commentClient;
     private final ThreadClient threadClient;
+    private final PlanTemplateClient planTemplateClient;
 
 
     private final static Map<Long, FocusArea> faCache = new HashMap<>();
@@ -94,6 +98,7 @@ public class Contest extends AbstractContest implements Serializable {
         contestClient = ContestClientUtil.getClient();
         contestTeamMemberClient = ContestTeamMemberClientUtil.getClient();
         ontologyClient = OntologyClientUtil.getClient();
+        planTemplateClient = PlanTemplateClientUtil.getClient();
         commentClient = CommentClientUtil.getClient();
         threadClient = ThreadClientUtil.getClient();
     }
@@ -102,6 +107,7 @@ public class Contest extends AbstractContest implements Serializable {
         contestClient = ContestClientUtil.getClient();
         contestTeamMemberClient = ContestTeamMemberClientUtil.getClient();
         ontologyClient = OntologyClientUtil.getClient();
+        planTemplateClient = PlanTemplateClientUtil.getClient();
         commentClient = CommentClientUtil.getClient();
         threadClient = ThreadClientUtil.getClient();
     }
@@ -112,6 +118,7 @@ public class Contest extends AbstractContest implements Serializable {
             contestClient = ContestClient.fromService(restService);
             contestTeamMemberClient = ContestTeamMemberClient.fromService(restService);
             ontologyClient = OntologyClient.fromService(restService);
+            planTemplateClient = PlanTemplateClient.fromService(restService);
             RestService commentService = restService.withServiceName(CoLabService.COMMENT.getServiceName());
             commentClient = CommentClient.fromService(commentService);
             threadClient = ThreadClient.fromService(commentService);
@@ -119,6 +126,7 @@ public class Contest extends AbstractContest implements Serializable {
             contestClient = ContestClientUtil.getClient();
             contestTeamMemberClient = ContestTeamMemberClientUtil.getClient();
             ontologyClient = OntologyClientUtil.getClient();
+            planTemplateClient = PlanTemplateClientUtil.getClient();
             commentClient = CommentClientUtil.getClient();
             threadClient = ThreadClientUtil.getClient();
         }
@@ -130,6 +138,7 @@ public class Contest extends AbstractContest implements Serializable {
         contestClient = ContestClient.fromService(this.restService);
         contestTeamMemberClient = ContestTeamMemberClient.fromService(this.restService);
         ontologyClient = OntologyClient.fromService(this.restService);
+        planTemplateClient = PlanTemplateClient.fromService(this.restService);
         RestService commentService =  restService.withServiceName(CoLabService.COMMENT.getServiceName());
         commentClient = CommentClient.fromService(commentService);
         threadClient = ThreadClient.fromService(commentService);
@@ -773,4 +782,8 @@ public class Contest extends AbstractContest implements Serializable {
         }
     }
 
+    public List<PlanSectionDefinition> getSections() {
+        return planTemplateClient.getPlanSectionDefinitionByPlanTemplateId(getPlanTemplateId(),
+                        true);
+    }
 }

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/templates/AbstractPlanSectionDefinition.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/contest/pojo/templates/AbstractPlanSectionDefinition.java
@@ -1,6 +1,7 @@
 package org.xcolab.client.contest.pojo.templates;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 abstract class AbstractPlanSectionDefinition implements Serializable {
 
@@ -20,6 +21,7 @@ abstract class AbstractPlanSectionDefinition implements Serializable {
     private String  additionalids;
     private Boolean locked;
     private Boolean contestintegrationrelevance;
+    private Boolean includeInJudgingReport;
 
     public AbstractPlanSectionDefinition() {}
 
@@ -38,38 +40,7 @@ abstract class AbstractPlanSectionDefinition implements Serializable {
         this.additionalids = value.additionalids;
         this.locked = value.locked;
         this.contestintegrationrelevance = value.contestintegrationrelevance;
-    }
-
-    public AbstractPlanSectionDefinition(
-        Long    id_,
-        String  type_,
-        String  admintitle,
-        String  title,
-        String  defaulttext,
-        String  helptext,
-        Integer characterlimit,
-        Long    focusareaid,
-        Long    tier,
-        String  allowedcontesttypeids,
-        String  allowedvalues,
-        String  additionalids,
-        Boolean locked,
-        Boolean contestintegrationrelevance
-    ) {
-        this.id_ = id_;
-        this.type_ = type_;
-        this.admintitle = admintitle;
-        this.title = title;
-        this.defaulttext = defaulttext;
-        this.helptext = helptext;
-        this.characterlimit = characterlimit;
-        this.focusareaid = focusareaid;
-        this.tier = tier;
-        this.allowedcontesttypeids = allowedcontesttypeids;
-        this.allowedvalues = allowedvalues;
-        this.additionalids = additionalids;
-        this.locked = locked;
-        this.contestintegrationrelevance = contestintegrationrelevance;
+        this.includeInJudgingReport = value.includeInJudgingReport;
     }
 
     public Long getId_() {
@@ -184,152 +155,46 @@ abstract class AbstractPlanSectionDefinition implements Serializable {
         this.contestintegrationrelevance = contestintegrationrelevance;
     }
 
+    public Boolean getIncludeInJudgingReport() {
+        return this.includeInJudgingReport;
+    }
+
+    public void setIncludeInJudgingReport(Boolean includeInJudgingReport) {
+        this.includeInJudgingReport = includeInJudgingReport;
+    }
+
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (obj == null) {
+        if (!(o instanceof AbstractPlanSectionDefinition)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final AbstractPlanSectionDefinition other = (AbstractPlanSectionDefinition) obj;
-        if (id_ == null) {
-            if (other.id_ != null) {
-                return false;
-            }
-        }
-        else if (!id_.equals(other.id_)) {
-            return false;
-        }
-        if (type_ == null) {
-            if (other.type_ != null) {
-                return false;
-            }
-        }
-        else if (!type_.equals(other.type_)) {
-            return false;
-        }
-        if (admintitle == null) {
-            if (other.admintitle != null) {
-                return false;
-            }
-        }
-        else if (!admintitle.equals(other.admintitle)) {
-            return false;
-        }
-        if (title == null) {
-            if (other.title != null) {
-                return false;
-            }
-        }
-        else if (!title.equals(other.title)) {
-            return false;
-        }
-        if (defaulttext == null) {
-            if (other.defaulttext != null) {
-                return false;
-            }
-        }
-        else if (!defaulttext.equals(other.defaulttext)) {
-            return false;
-        }
-        if (helptext == null) {
-            if (other.helptext != null) {
-                return false;
-            }
-        }
-        else if (!helptext.equals(other.helptext)) {
-            return false;
-        }
-        if (characterlimit == null) {
-            if (other.characterlimit != null) {
-                return false;
-            }
-        }
-        else if (!characterlimit.equals(other.characterlimit)) {
-            return false;
-        }
-        if (focusareaid == null) {
-            if (other.focusareaid != null) {
-                return false;
-            }
-        }
-        else if (!focusareaid.equals(other.focusareaid)) {
-            return false;
-        }
-        if (tier == null) {
-            if (other.tier != null) {
-                return false;
-            }
-        }
-        else if (!tier.equals(other.tier)) {
-            return false;
-        }
-        if (allowedcontesttypeids == null) {
-            if (other.allowedcontesttypeids != null) {
-                return false;
-            }
-        }
-        else if (!allowedcontesttypeids.equals(other.allowedcontesttypeids)) {
-            return false;
-        }
-        if (allowedvalues == null) {
-            if (other.allowedvalues != null) {
-                return false;
-            }
-        }
-        else if (!allowedvalues.equals(other.allowedvalues)) {
-            return false;
-        }
-        if (additionalids == null) {
-            if (other.additionalids != null) {
-                return false;
-            }
-        }
-        else if (!additionalids.equals(other.additionalids)) {
-            return false;
-        }
-        if (locked == null) {
-            if (other.locked != null) {
-                return false;
-            }
-        }
-        else if (!locked.equals(other.locked)) {
-            return false;
-        }
-        if (contestintegrationrelevance == null) {
-            if (other.contestintegrationrelevance != null) {
-                return false;
-            }
-        }
-        else if (!contestintegrationrelevance.equals(other.contestintegrationrelevance)) {
-            return false;
-        }
-        return true;
+        AbstractPlanSectionDefinition that = (AbstractPlanSectionDefinition) o;
+        return Objects.equals(getId_(), that.getId_())
+                && Objects.equals(getType_(), that.getType_())
+                && Objects.equals(admintitle, that.admintitle)
+                && Objects.equals(getTitle(), that.getTitle())
+                && Objects.equals(defaulttext, that.defaulttext)
+                && Objects.equals(helptext, that.helptext)
+                && Objects.equals(characterlimit, that.characterlimit)
+                && Objects.equals(focusareaid, that.focusareaid)
+                && Objects.equals(getTier(), that.getTier())
+                && Objects.equals(allowedcontesttypeids, that.allowedcontesttypeids)
+                && Objects.equals(allowedvalues, that.allowedvalues)
+                && Objects.equals(additionalids, that.additionalids)
+                && Objects.equals(getLocked(), that.getLocked())
+                && Objects.equals(contestintegrationrelevance, that.contestintegrationrelevance)
+                && Objects.equals(getIncludeInJudgingReport(), that.getIncludeInJudgingReport());
     }
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((id_ == null) ? 0 : id_.hashCode());
-        result = prime * result + ((type_ == null) ? 0 : type_.hashCode());
-        result = prime * result + ((admintitle == null) ? 0 : admintitle.hashCode());
-        result = prime * result + ((title == null) ? 0 : title.hashCode());
-        result = prime * result + ((defaulttext == null) ? 0 : defaulttext.hashCode());
-        result = prime * result + ((helptext == null) ? 0 : helptext.hashCode());
-        result = prime * result + ((characterlimit == null) ? 0 : characterlimit.hashCode());
-        result = prime * result + ((focusareaid == null) ? 0 : focusareaid.hashCode());
-        result = prime * result + ((tier == null) ? 0 : tier.hashCode());
-        result = prime * result + ((allowedcontesttypeids == null) ? 0 : allowedcontesttypeids.hashCode());
-        result = prime * result + ((allowedvalues == null) ? 0 : allowedvalues.hashCode());
-        result = prime * result + ((additionalids == null) ? 0 : additionalids.hashCode());
-        result = prime * result + ((locked == null) ? 0 : locked.hashCode());
-        result = prime * result + ((contestintegrationrelevance == null) ? 0 : contestintegrationrelevance.hashCode());
-        return result;
+        return Objects.hash(getId_(), getType_(), admintitle, getTitle(), defaulttext, helptext,
+                characterlimit, focusareaid, getTier(), allowedcontesttypeids, allowedvalues,
+                additionalids, getLocked(), contestintegrationrelevance,
+                getIncludeInJudgingReport());
     }
 
     @Override

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/pojo/Proposal.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/pojo/Proposal.java
@@ -286,6 +286,7 @@ public class Proposal extends AbstractProposal {
     public String getCleanPitch() {
         return HtmlUtil.cleanAll(getPitch());
     }
+
     public String getPitch() {
         return proposalAttributeHelper.getAttributeValueString(ProposalAttributeKeys.PITCH, "");
     }

--- a/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/plansectiondefinition/PlanSectionDefinitionDaoImpl.java
+++ b/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/domain/plansectiondefinition/PlanSectionDefinitionDaoImpl.java
@@ -5,6 +5,8 @@ import org.jooq.Record;
 import org.jooq.SelectQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.Assert;
+
 import org.xcolab.model.tables.pojos.PlanSectionDefinition;
 import org.xcolab.model.tables.records.PlanSectionDefinitionRecord;
 import org.xcolab.service.contest.exceptions.NotFoundException;
@@ -17,9 +19,13 @@ import static org.xcolab.model.Tables.PLAN_TEMPLATE_SECTION;
 @Repository
 public class PlanSectionDefinitionDaoImpl implements PlanSectionDefinitionDao {
 
-    @Autowired
-    private DSLContext dslContext;
+    private final DSLContext dslContext;
 
+    @Autowired
+    public PlanSectionDefinitionDaoImpl(DSLContext dslContext) {
+        Assert.notNull(dslContext, "DSLContext is required");
+        this.dslContext = dslContext;
+    }
 
     @Override
     public List<PlanSectionDefinition> findByGiven(Long planTemplateId, Boolean weight) {
@@ -68,6 +74,7 @@ public class PlanSectionDefinitionDaoImpl implements PlanSectionDefinitionDao {
                 .set(PLAN_SECTION_DEFINITION.ADDITIONAL_IDS, planSectionDefinition.getAdditionalIds())
                 .set(PLAN_SECTION_DEFINITION.LOCKED, planSectionDefinition.getLocked())
                 .set(PLAN_SECTION_DEFINITION.CONTEST_INTEGRATION_RELEVANCE, planSectionDefinition.getContestIntegrationRelevance())
+                .set(PLAN_SECTION_DEFINITION.INCLUDE_IN_JUDGING_REPORT, planSectionDefinition.getIncludeInJudgingReport())
                 .returning(PLAN_SECTION_DEFINITION.ID_)
                 .fetchOne();
         if (ret != null) {
@@ -102,8 +109,8 @@ public class PlanSectionDefinitionDaoImpl implements PlanSectionDefinitionDao {
                 .set(PLAN_SECTION_DEFINITION.ADDITIONAL_IDS, planSectionDefinition.getAdditionalIds())
                 .set(PLAN_SECTION_DEFINITION.LOCKED, planSectionDefinition.getLocked())
                 .set(PLAN_SECTION_DEFINITION.CONTEST_INTEGRATION_RELEVANCE, planSectionDefinition.getContestIntegrationRelevance())
+                .set(PLAN_SECTION_DEFINITION.INCLUDE_IN_JUDGING_REPORT, planSectionDefinition.getIncludeInJudgingReport())
                 .where(PLAN_SECTION_DEFINITION.ID_.eq(planSectionDefinition.getId_()))
                 .execute() > 0;
     }
-
 }

--- a/sql/deployments/deployment-2017-10-02.sql
+++ b/sql/deployments/deployment-2017-10-02.sql
@@ -1,0 +1,2 @@
+-- COLAB-2273
+ALTER TABLE xcolab_PlanSectionDefinition ADD includeInJudgingReport TINYINT(4) DEFAULT 0;

--- a/sql/starter/xcolab-schema.sql
+++ b/sql/starter/xcolab-schema.sql
@@ -934,6 +934,7 @@ CREATE TABLE `xcolab_PlanSectionDefinition` (
   `additionalIds` varchar(75) DEFAULT NULL,
   `locked` tinyint(4) DEFAULT NULL,
   `contestIntegrationRelevance` tinyint(4) DEFAULT NULL,
+  includeInJudgingReport TINYINT(4) DEFAULT 0,
   PRIMARY KEY (`id_`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/SectionDefinitionWrapper.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/SectionDefinitionWrapper.java
@@ -1,6 +1,5 @@
 package org.xcolab.view.pages.contestmanagement.wrappers;
 
-
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -23,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class SectionDefinitionWrapper implements Serializable,Comparable{
+public class SectionDefinitionWrapper implements Serializable, Comparable {
 
     private Long id;
     private String type = "";
@@ -43,6 +42,7 @@ public class SectionDefinitionWrapper implements Serializable,Comparable{
     private boolean isSectionNew;
     private boolean templateSection;
     private boolean contestIntegrationRelevance;
+    private boolean includeInJudgingReport;
     private int weight;
 
     private List<Long> allowedContestTypeIds = new ArrayList<>();
@@ -257,19 +257,7 @@ public class SectionDefinitionWrapper implements Serializable,Comparable{
         if (id == null || createNew) {
             psd = new PlanSectionDefinition();
 
-            psd.setType_(this.getType());
-            psd.setTitle(this.getTitle());
-            psd.setDefaultText(this.getDefaultText());
-            psd.setCharacterLimit(this.getCharacterLimit());
-            psd.setHelpText(this.getHelpText());
-            psd.setTier(this.getLevel());
-            psd.setFocusAreaId(this.getFocusAreaId());
-            psd.setAdditionalIds(this.getAdditionalIds());
-            psd.setAllowedValues(this.getAllowedValues());
-            psd.setAllowedContestTypeIds(
-                    IdListUtil.getStringFromIds(this.getAllowedContestTypeIds()));
-            psd.setContestIntegrationRelevance(this.isContestIntegrationRelevance());
-            psd.setLocked(false);
+            populatePlanSectionDefinition(psd);
 
             psd = PlanTemplateClientUtil.createPlanSectionDefinition(psd);
             id = psd.getId_();
@@ -279,21 +267,7 @@ public class SectionDefinitionWrapper implements Serializable,Comparable{
             pdc = PointsClientUtil
                     .getPointsDistributionConfigurationByTargetPlanSectionDefinitionId(id);
 
-
-            psd.setType_(this.getType());
-            psd.setTitle(this.getTitle());
-            psd.setDefaultText(this.getDefaultText());
-            psd.setCharacterLimit(this.getCharacterLimit());
-            psd.setHelpText(this.getHelpText());
-            psd.setTier(this.getLevel());
-            psd.setFocusAreaId(this.getFocusAreaId());
-            psd.setAdditionalIds(this.getAdditionalIds());
-            psd.setAllowedValues(this.getAllowedValues());
-            psd.setAllowedContestTypeIds(
-                    IdListUtil.getStringFromIds(this.getAllowedContestTypeIds()));
-            psd.setContestIntegrationRelevance(this.isContestIntegrationRelevance());
-            psd.setLocked(false);
-
+            populatePlanSectionDefinition(psd);
 
             if (pdc != null) {
                 if (pointType == 0L) {
@@ -335,6 +309,23 @@ public class SectionDefinitionWrapper implements Serializable,Comparable{
 
         PlanTemplateClientUtil.updatePlanSectionDefinition(psd);
 
+    }
+
+    private void populatePlanSectionDefinition(PlanSectionDefinition psd) {
+        psd.setType_(this.getType());
+        psd.setTitle(this.getTitle());
+        psd.setDefaultText(this.getDefaultText());
+        psd.setCharacterLimit(this.getCharacterLimit());
+        psd.setHelpText(this.getHelpText());
+        psd.setTier(this.getLevel());
+        psd.setFocusAreaId(this.getFocusAreaId());
+        psd.setAdditionalIds(this.getAdditionalIds());
+        psd.setAllowedValues(this.getAllowedValues());
+        psd.setAllowedContestTypeIds(
+                IdListUtil.getStringFromIds(this.getAllowedContestTypeIds()));
+        psd.setContestIntegrationRelevance(this.isContestIntegrationRelevance());
+        psd.setIncludeInJudgingReport(this.isIncludeInJudgingReport());
+        psd.setLocked(false);
     }
 
     public String getTitle() {
@@ -391,6 +382,14 @@ public class SectionDefinitionWrapper implements Serializable,Comparable{
 
     public void setContestIntegrationRelevance(boolean contestIntegrationRelevance) {
         this.contestIntegrationRelevance = contestIntegrationRelevance;
+    }
+
+    public boolean isIncludeInJudgingReport() {
+        return includeInJudgingReport;
+    }
+
+    public void setIncludeInJudgingReport(boolean includeInJudgingReport) {
+        this.includeInJudgingReport = includeInJudgingReport;
     }
 
     public Long getFocusAreaId() {
@@ -535,6 +534,7 @@ public class SectionDefinitionWrapper implements Serializable,Comparable{
     public int hashCode() {
         return new HashCodeBuilder()
                 .append(contestIntegrationRelevance)
+                .append(includeInJudgingReport)
                 .append(level)
                 .append(pointType)
                 .append(id)
@@ -570,6 +570,7 @@ public class SectionDefinitionWrapper implements Serializable,Comparable{
                 .append(other.getAdditionalIds(), this.getAdditionalIds())
                 .append(other.getCharacterLimit(), this.getCharacterLimit())
                 .append(other.isContestIntegrationRelevance(), this.isContestIntegrationRelevance())
+                .append(other.isIncludeInJudgingReport(), this.isIncludeInJudgingReport())
                 .append(other.getFocusAreaId(), this.getFocusAreaId())
                 .append(other.getLevel(), this.getLevel())
                 .append(other.getPointType(), this.getPointType())

--- a/view/src/main/java/org/xcolab/view/pages/proposals/judging/ProposalReviewCsvExporter.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/judging/ProposalReviewCsvExporter.java
@@ -128,10 +128,22 @@ public class ProposalReviewCsvExporter {
                 .getContestPhaseType(proposalReview.getContestPhase().getContestPhaseType())
                 .getName();
 
+        Proposal proposal = proposalReview.getProposal();
+
+        final String dataFields = getDataFields(proposal);
+
+        return String.format("%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s",
+                TQF, escapeQuote(proposalName),
+                delimiter, escapeQuote(proposalReview.getProposalTeamAuthor()),
+                delimiter, proposalReview.getProposalUrl(),
+                delimiter, proposalReview.getProposal().getCleanPitch(),
+                dataFields +
+                delimiter, escapeQuote(contestPhaseName), delimiter);
+    }
+
+    private String getDataFields(Proposal proposal) {
         StringBuilder dataFields = new StringBuilder(TQF);
         for (PlanSectionDefinition sectionDefinition : contest.getSections()) {
-            Proposal proposal = proposalReview.getProposal();
-
             if (sectionDefinition.getIncludeInJudgingReport()) {
                 PlanSectionDefinition proposalSection =
                         new PlanSectionDefinition(sectionDefinition, proposal);
@@ -139,23 +151,37 @@ public class ProposalReviewCsvExporter {
                         escapeQuote(HtmlUtil.cleanAll(proposalSection.getContent())), delimiter));
             }
         }
-
-        return String.format("%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s",
-                TQF, escapeQuote(proposalName),
-                delimiter, escapeQuote(proposalReview.getProposalTeamAuthor()),
-                delimiter, proposalReview.getProposalUrl(),
-                delimiter, proposalReview.getProposal().getCleanPitch(),
-                dataFields.toString() +
-                delimiter, escapeQuote(contestPhaseName), delimiter);
+        return dataFields.toString();
     }
 
     private String getTableHeader() {
+        final String ratingSubHeader = getRatingSubHeader();
+        final String dataFieldHeaders = getDataFieldHeaders();
+
+        return TQF + "\"Proposal title\"" + delimiter +
+                "\"Author/Team name\"" + delimiter +
+                "\"Proposal URL\"" + delimiter +
+                "\"Proposal Pitch\"" + delimiter +
+                dataFieldHeaders +
+                "\"Contest Phase\"" + delimiter +
+                "\"Judge\"" + delimiter +
+                "\"Average\"" + delimiter +
+                ratingSubHeader +
+                "\"ShouldAdvance\"" + delimiter +
+                "\"Comment\"" + delimiter +
+                "\"Presented by\"" + "\n";
+    }
+
+    private String getRatingSubHeader() {
         StringBuilder ratingSubHeader = new StringBuilder(TQF);
         for (ProposalRatingType ratingType : ratingTypes) {
             String ratingTitle = ratingType.getLabel();
             ratingSubHeader.append(String.format("\"%s\"%s", ratingTitle, delimiter));
         }
+        return ratingSubHeader.toString();
+    }
 
+    private String getDataFieldHeaders() {
         StringBuilder dataFieldHeaders = new StringBuilder(TQF);
         for (PlanSectionDefinition sectionDefinition : contest.getSections()) {
             if (sectionDefinition.getIncludeInJudgingReport()) {
@@ -163,19 +189,7 @@ public class ProposalReviewCsvExporter {
                         String.format("\"%s\"%s", sectionDefinition.getTitle(), delimiter));
             }
         }
-
-        return TQF + "\"Proposal title\"" + delimiter +
-                "\"Author/Team name\"" + delimiter +
-                "\"Proposal URL\"" + delimiter +
-                "\"Proposal Pitch\"" + delimiter +
-                dataFieldHeaders.toString() +
-                "\"Contest Phase\"" + delimiter +
-                "\"Judge\"" + delimiter +
-                "\"Average\"" + delimiter +
-                ratingSubHeader.toString() +
-                "\"ShouldAdvance\"" + delimiter +
-                "\"Comment\"" + delimiter +
-                "\"Presented by\"" + "\n";
+        return dataFieldHeaders.toString();
     }
 
     private String deAccent(String str) {

--- a/view/src/main/java/org/xcolab/view/pages/proposals/judging/ProposalReviewCsvExporter.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/judging/ProposalReviewCsvExporter.java
@@ -143,12 +143,10 @@ public class ProposalReviewCsvExporter {
 
     private String getDataFields(Proposal proposal) {
         StringBuilder dataFields = new StringBuilder(TQF);
-        for (PlanSectionDefinition sectionDefinition : contest.getSections()) {
+        for (PlanSectionDefinition sectionDefinition : proposal.getSections()) {
             if (sectionDefinition.getIncludeInJudgingReport()) {
-                PlanSectionDefinition proposalSection =
-                        new PlanSectionDefinition(sectionDefinition, proposal);
                 dataFields.append(String.format("\"%s\"%s",
-                        escapeQuote(HtmlUtil.cleanAll(proposalSection.getContent())), delimiter));
+                        escapeQuote(HtmlUtil.cleanAll(sectionDefinition.getContent())), delimiter));
             }
         }
         return dataFields.toString();

--- a/view/src/main/java/org/xcolab/view/pages/proposals/judging/ProposalReviewCsvExporter.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/judging/ProposalReviewCsvExporter.java
@@ -121,7 +121,12 @@ public class ProposalReviewCsvExporter {
                 .getContestPhaseType(proposalReview.getContestPhase().getContestPhaseType())
                 .getName();
 
-        return String.format("%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s", TQF, escapeQuote(proposalName), delimiter, escapeQuote(proposalReview.getProposalTeamAuthor()), delimiter, proposalReview.getProposalUrl(), delimiter, escapeQuote(contestPhaseName), delimiter);
+        return String.format("%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s\"%s",
+                TQF, escapeQuote(proposalName),
+                delimiter, escapeQuote(proposalReview.getProposalTeamAuthor()),
+                delimiter, proposalReview.getProposalUrl(),
+                delimiter, proposalReview.getProposal().getCleanPitch(),
+                delimiter, escapeQuote(contestPhaseName), delimiter);
     }
 
     private String getTableHeader() {
@@ -134,6 +139,7 @@ public class ProposalReviewCsvExporter {
         return TQF + "\"Proposal title\"" + delimiter +
                 "\"Author/Team name\"" + delimiter +
                 "\"Proposal URL\"" + delimiter +
+                "\"Proposal Pitch\"" + delimiter +
                 "\"Contest Phase\"" + delimiter +
                 "\"Judge\"" + delimiter +
                 "\"Average\"" + delimiter +

--- a/view/src/main/java/org/xcolab/view/pages/proposals/view/action/JudgingCsvController.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/view/action/JudgingCsvController.java
@@ -169,7 +169,7 @@ public class JudgingCsvController {
         }
 
         ProposalReviewCsvExporter csvExporter =
-                new ProposalReviewCsvExporter(proposalToProposalReviewsMap,
+                new ProposalReviewCsvExporter(contest, proposalToProposalReviewsMap,
                         new ArrayList<>(occurringRatingTypes));
 
         return csvExporter.getCsvString();

--- a/view/src/main/java/org/xcolab/view/pages/proposals/view/action/JudgingCsvController.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/view/action/JudgingCsvController.java
@@ -9,14 +9,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import org.xcolab.client.admin.attributes.platform.PlatformAttributeKey;
-import org.xcolab.client.contest.ContestClientUtil;
 import org.xcolab.client.contest.ContestTeamMemberClientUtil;
 import org.xcolab.client.contest.pojo.Contest;
 import org.xcolab.client.contest.pojo.phases.ContestPhase;
-import org.xcolab.client.members.MembersClient;
-import org.xcolab.client.members.exceptions.MemberNotFoundException;
 import org.xcolab.client.members.pojo.Member;
 import org.xcolab.client.proposals.ProposalJudgeRatingClientUtil;
+import org.xcolab.client.proposals.ProposalPhaseClient;
 import org.xcolab.client.proposals.ProposalPhaseClientUtil;
 import org.xcolab.client.proposals.pojo.Proposal;
 import org.xcolab.client.proposals.pojo.evaluation.judges.ProposalRating;
@@ -29,6 +27,7 @@ import org.xcolab.view.pages.proposals.judging.ProposalRatingWrapper;
 import org.xcolab.view.pages.proposals.judging.ProposalReview;
 import org.xcolab.view.pages.proposals.judging.ProposalReviewCsvExporter;
 import org.xcolab.view.pages.proposals.permissions.ProposalsPermissions;
+import org.xcolab.view.pages.proposals.utils.context.ClientHelper;
 import org.xcolab.view.pages.proposals.utils.context.ProposalContext;
 
 import java.io.ByteArrayOutputStream;
@@ -43,6 +42,8 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import static org.xcolab.view.util.entity.EntityIdListUtil.MEMBERS;
 
 @Controller
 @RequestMapping("/contests/{contestYear}/{contestUrlName}")
@@ -93,13 +94,12 @@ public class JudgingCsvController {
         List<Proposal> stillActiveProposals = proposalContext.getClients().getProposalClient()
                 .getActiveProposalsInContestPhase(currentPhase.getContestPhasePK());
         Set<ProposalRatingType> occurringRatingTypes = new HashSet<>();
-        Set<Member> occurringJudges = new HashSet<>();
 
-        for (ContestPhase judgingPhase : ContestClientUtil
-                .getAllContestPhases(contest.getContestPK())) {
+        for (ContestPhase judgingPhase : contest.getPhases()) {
             if (!judgingPhase.getFellowScreeningActive()) {
                 continue;
             }
+
             for (Proposal proposal : stillActiveProposals) {
                 ProposalContestPhaseAttribute fellowActionAttribute = ProposalPhaseClientUtil
                         .getProposalContestPhaseAttribute(proposal.getProposalId(),
@@ -115,7 +115,6 @@ public class JudgingCsvController {
                             && judgingPhase.getFellowScreeningActive()) {
                         continue;
                     }
-
 
                     final String proposalUrl = PlatformAttributeKey.COLAB_URL.get() + proposal
                             .getProposalLinkUrl(contest, judgingPhase.getContestPhasePK());
@@ -143,7 +142,6 @@ public class JudgingCsvController {
                         occurringRatingTypes.add(ratingWrapper.getRatingType());
                         if (rating.getCommentEnabled()) {
                             proposalReview.addReview(ratingWrapper.getUser(), rating.getComment_());
-                            occurringJudges.add(ratingWrapper.getUser());
                         }
                         if (StringUtils.isNotBlank(rating.getOtherDataString())) {
                             proposalReview.addShouldAdvanceDecision(ratingWrapper.getUser(),
@@ -179,42 +177,29 @@ public class JudgingCsvController {
 
     private List<Member> getProposalReviewingJudges(Proposal proposal, ContestPhase judgingPhase,
             ProposalContext proposalContext) {
-        List<Member> selectedJudges = null;
+
+        final ClientHelper clients = proposalContext.getClients();
+        final ProposalPhaseClient proposalPhaseClient = clients.getProposalPhaseClient();
+
 
         if (judgingPhase.getFellowScreeningActive()) {
-            final String judgeIdString = proposalContext.getClients().getProposalPhaseClient().
-                    getProposalContestPhaseAttribute(proposal.getProposalId(),
+            final ProposalContestPhaseAttribute selectedJudgesAttribute = proposalPhaseClient
+                    .getProposalContestPhaseAttribute(proposal.getProposalId(),
                             judgingPhase.getContestPhasePK(),
-                            ProposalContestPhaseAttributeKeys.SELECTED_JUDGES).getStringValue();
-
-            selectedJudges = new ArrayList<>();
-
-            for (String element : judgeIdString.split(";")) {
-
-                try {
-                    long userId = Long.parseLong(element);
-                    Member judge = MembersClient.getMember(userId);
-                    selectedJudges.add(judge);
-                } catch (MemberNotFoundException | NumberFormatException ignore) {
-
-                }
+                            ProposalContestPhaseAttributeKeys.SELECTED_JUDGES);
+            if (selectedJudgesAttribute == null) {
+                throw new IllegalStateException("Fellow screening active,"
+                        + " but no judges were selected for this contest.");
             }
+
+            final String judgeIdString = selectedJudgesAttribute.getStringValue();
+            return MEMBERS.fromIdString(judgeIdString);
+
         } else {
             // Choose all judges
-            try {
-                List<Long> members = ContestTeamMemberClientUtil
+            List<Long> judgeIds = ContestTeamMemberClientUtil
                         .getJudgesForContest(judgingPhase.getContestPK());
-                selectedJudges = new ArrayList<>();
-                for (Long memberId : members) {
-                    selectedJudges.add(MembersClient.getMember(memberId));
-                }
-            } catch (MemberNotFoundException ignored) {
-
-            }
+            return MEMBERS.fromIdList(judgeIds);
         }
-
-        return selectedJudges;
     }
-
 }
-

--- a/view/src/main/java/org/xcolab/view/util/entity/EntityIdListUtil.java
+++ b/view/src/main/java/org/xcolab/view/util/entity/EntityIdListUtil.java
@@ -4,6 +4,8 @@ import org.xcolab.client.admin.ContestTypeClient;
 import org.xcolab.client.admin.pojo.ContestType;
 import org.xcolab.client.contest.ContestClientUtil;
 import org.xcolab.client.contest.pojo.Contest;
+import org.xcolab.client.members.MembersClient;
+import org.xcolab.client.members.pojo.Member;
 import org.xcolab.client.proposals.ProposalClientUtil;
 import org.xcolab.client.proposals.pojo.Proposal;
 import org.xcolab.util.IdListUtil;
@@ -36,6 +38,9 @@ public final class EntityIdListUtil {
      */
     public final static IdListObjectConverter<ContestType> CONTEST_TYPES =
             new IdListObjectConverter<>(ContestTypeClient::getContestType, ContestType::getId);
+
+    public final static IdListObjectConverter<Member> MEMBERS =
+            new IdListObjectConverter<>(MembersClient::getMemberUnchecked, Member::getUserId);
 
 
     public static class IdListObjectConverter<T> {

--- a/view/src/main/resources/static/sass/partials/bootstrap/_form.scss
+++ b/view/src/main/resources/static/sass/partials/bootstrap/_form.scss
@@ -62,3 +62,17 @@ fieldset[disabled] .form-control {
   border: 1px solid $t-Color__grey--light;
   border-radius: $bs-form-control__borderRadius;
 }
+
+//workaround to override legacy input and label rules
+.checkbox {
+  label {
+    float: none !important;
+    width: initial !important;
+  }
+
+  input[type=checkbox] {
+    float: none !important;
+    height: initial !important;
+    width: initial !important;
+  }
+}

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/proposalTemplateTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/proposalTemplateTab.jspx
@@ -108,6 +108,15 @@
 								</form:select>
 							</div>
 
+                            <div class="checkbox">
+                                <label>
+                                    <form:checkbox path="sections[${x.index}].includeInJudgingReport"
+                                                   id="sections${x.index}.includeInJudgingReport"
+                                                   data-form-name="includeInJudgingReport"/>
+                                    <strong>Should the content of this section be included in the judging report CSV?</strong>
+                                </label>
+                            </div>
+
                             <div class="js-sectionTypeDependent" data-section-type="PROPOSAL"
                                     style="display: none">
                                 <div class="levelVisible">
@@ -140,11 +149,10 @@
 
                                     <div class="checkbox">
                                         <label>
-                                            <strong>Is this proposal reference field used for contest integration?</strong><br/>
                                             <form:checkbox path="sections[${x.index}].contestIntegrationRelevance"
                                                            id="sections${x.index}.contestIntegrationRelevance"
-                                                           data-form-name="contestIntegrationRelevance">
-                                            </form:checkbox>
+                                                           data-form-name="contestIntegrationRelevance"/>
+                                            <strong>Is this proposal reference field used for contest integration?</strong>
                                         </label>
                                     </div>
                                 </div>


### PR DESCRIPTION
This pull requests adds the content of the pitch field (present in all proposals) to the judging CSV and adds the possibility to indicate that a template section should also be included in the report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/38)
<!-- Reviewable:end -->
