### PR TITLE
[COLAB-2249] Fix Supporter Count Refresh

### DIFF
--- a/view/src/main/java/org/xcolab/view/pages/proposals/view/action/SupportProposalActionController.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/view/action/SupportProposalActionController.java
@@ -11,6 +11,8 @@ import org.xcolab.client.contest.exceptions.ContestNotFoundException;
 import org.xcolab.client.contest.pojo.Contest;
 import org.xcolab.client.members.pojo.Member;
 import org.xcolab.client.proposals.ProposalMemberRatingClient;
+import org.xcolab.util.http.ServiceRequestUtils;
+import org.xcolab.util.http.caching.CacheName;
 import org.xcolab.view.errors.AccessDeniedPage;
 import org.xcolab.view.pages.loginregister.SharedColabUtil;
 import org.xcolab.view.pages.proposals.exceptions.ProposalsAuthorizationException;
@@ -65,6 +67,7 @@ public class SupportProposalActionController {
 
             }
         }
+        ServiceRequestUtils.clearCache(CacheName.MISC_REQUEST);
         String proposalLinkUrl =
                 proposalContext.getProposal().getProposalLinkUrl(proposalContext.getContest());
         if (!StringUtils.isBlank(forwardToTab)) {


### PR DESCRIPTION
This PR fixes the issue that the supporter count would sometimes not update after clicking the (retract) support button on a proposal's details page by clearing the `MISC_REQUEST` cache when the support button is clicked..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/40)
<!-- Reviewable:end -->
