### PR TITLE
[COLAB-2266] Filter proposals from private contests in proposal picker

### DIFF
--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/ProposalClient.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/ProposalClient.java
@@ -144,7 +144,7 @@ public final class ProposalClient {
                 .execute(), proposalService);
     }
 
-    public List<Proposal> getProposalsByTypesAndTiers(List<Long> contestTypeIds,
+    public List<Proposal> getProposalsInPublicContests(List<Long> contestTypeIds,
             List<Long> contestTierIds, String filterText) {
 
         return DtoUtil.toPojos(proposalResource.list()
@@ -152,7 +152,8 @@ public final class ProposalClient {
                 .optionalQueryParam("filterText", filterText)
                 .optionalQueryParam("contestTypeIds", contestTypeIds)
                 .optionalQueryParam("contestTierIds", contestTierIds)
-                .optionalQueryParam("visible", true)
+                .queryParam("visible", true)
+                .queryParam("contestPrivate", false)
                 .withCache(CacheName.MISC_SHORT)
                 .execute(), proposalService);
     }

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/ProposalClientUtil.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/ProposalClientUtil.java
@@ -247,7 +247,7 @@ public final class ProposalClientUtil {
     }
     public static  List<Proposal> getProposalsByCurrentContests(List<Long> contestTypeIds, List<Long> contestTierIds,
             String filterText) {
-        return client.getProposalsByTypesAndTiers(contestTypeIds, contestTierIds, filterText);
+        return client.getProposalsInPublicContests(contestTypeIds, contestTierIds, filterText);
     }
 
     public static Group_ createGroup(Group_ group) {

--- a/view/src/main/java/org/xcolab/view/pages/proposals/utils/picker/ProposalPickerFilterUtil.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/utils/picker/ProposalPickerFilterUtil.java
@@ -142,7 +142,7 @@ public class ProposalPickerFilterUtil {
             proposals = proposalClient.getProposalsInContest(contestPK);
         } else {
             final List<Long> allowedTiers = getAllowedTiers(planSectionDefinition.getTier());
-            proposals = proposalClient.getProposalsByTypesAndTiers(contestTypes, allowedTiers,
+            proposals = proposalClient.getProposalsInPublicContests(contestTypes, allowedTiers,
                     filterText.isEmpty() ? null : filterText);
         }
 


### PR DESCRIPTION
This pull request filters proposal from private contests when requesting proposals for the proposal picker. The microservice already supported the attribute, so I just added it to the client method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/43)
<!-- Reviewable:end -->
