### PR TITLE
[COLAB-2359] login link logins not recorded

### DIFF
--- a/view/src/main/java/org/xcolab/view/auth/handlers/AuthenticationSuccessHandler.java
+++ b/view/src/main/java/org/xcolab/view/auth/handlers/AuthenticationSuccessHandler.java
@@ -1,16 +1,14 @@
 package org.xcolab.view.auth.handlers;
 
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication
-        .SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 
 import org.xcolab.client.members.MembersClient;
 import org.xcolab.client.members.PermissionsClient;
 import org.xcolab.client.members.pojo.Member;
+import org.xcolab.util.exceptions.InternalException;
 import org.xcolab.view.auth.AuthenticationService;
 import org.xcolab.view.pages.redballoon.utils.BalloonService;
 
@@ -22,8 +20,6 @@ import javax.servlet.http.HttpServletResponse;
 
 public class AuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(AuthenticationSuccessHandler.class);
-
     private final AuthenticationService authenticationService;
     private final BalloonService balloonService;
     private final boolean allowLogin;
@@ -34,12 +30,19 @@ public class AuthenticationSuccessHandler extends SavedRequestAwareAuthenticatio
         this.balloonService = balloonService;
         this.allowLogin = allowLogin;
         setDefaultTargetUrl("/");
+
+        //TODO COLAB-2362: Rethink circular dependency
+        authenticationService.setAuthenticationSuccessHandler(this);
     }
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-            Authentication authentication) throws ServletException, IOException {
+            Authentication authentication) throws IOException {
+        onAuthenticationSuccess(request, response, authentication, true);
+    }
 
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication, boolean redirectOnSuccess) throws IOException {
         final Member member = authenticationService.getRealMemberOrNull();
 
         if (!allowLogin && !PermissionsClient.canAdminAll(member)) {
@@ -53,13 +56,20 @@ public class AuthenticationSuccessHandler extends SavedRequestAwareAuthenticatio
         String refererHeader = request.getHeader(HttpHeaders.REFERER);
         MembersClient.createLoginLog(member.getId_(), request.getRemoteAddr(), refererHeader);
 
-        final String redirect = request.getParameter("redirect");
-        if (StringUtils.isNotBlank(redirect)) {
-            getRedirectStrategy().sendRedirect(request, response, redirect);
-        } else if (StringUtils.isNotBlank(refererHeader) && !refererHeader.endsWith("/login")) {
-            getRedirectStrategy().sendRedirect(request, response, refererHeader);
-        } else {
-            super.onAuthenticationSuccess(request, response, authentication);
+        if (redirectOnSuccess) {
+            final String redirect = request.getParameter("redirect");
+            if (StringUtils.isNotBlank(redirect)) {
+                getRedirectStrategy().sendRedirect(request, response, redirect);
+            } else if (StringUtils.isNotBlank(refererHeader) && !refererHeader.endsWith("/login")) {
+                getRedirectStrategy().sendRedirect(request, response, refererHeader);
+            } else {
+                try {
+                    super.onAuthenticationSuccess(request, response, authentication);
+                } catch (ServletException e) {
+                    // Not reachable - no ServletException is thrown by the implementations
+                    throw new InternalException(e);
+                }
+            }
         }
     }
 }

--- a/view/src/main/java/org/xcolab/view/auth/handlers/AuthenticationSuccessHandler.java
+++ b/view/src/main/java/org/xcolab/view/auth/handlers/AuthenticationSuccessHandler.java
@@ -12,7 +12,7 @@ import org.xcolab.client.members.MembersClient;
 import org.xcolab.client.members.PermissionsClient;
 import org.xcolab.client.members.pojo.Member;
 import org.xcolab.view.auth.AuthenticationService;
-import org.xcolab.view.pages.redballon.utils.BalloonService;
+import org.xcolab.view.pages.redballoon.utils.BalloonService;
 
 import java.io.IOException;
 

--- a/view/src/main/java/org/xcolab/view/config/spring/beans/WebSecurityBeansConfig.java
+++ b/view/src/main/java/org/xcolab/view/config/spring/beans/WebSecurityBeansConfig.java
@@ -15,7 +15,7 @@ import org.xcolab.view.auth.AuthenticationService;
 import org.xcolab.view.auth.handlers.AuthenticationSuccessHandler;
 import org.xcolab.view.auth.login.spring.MemberDetailsService;
 import org.xcolab.view.config.spring.properties.WebProperties;
-import org.xcolab.view.pages.redballon.utils.BalloonService;
+import org.xcolab.view.pages.redballoon.utils.BalloonService;
 
 import java.util.UUID;
 

--- a/view/src/main/java/org/xcolab/view/config/spring/beans/WebSecurityBeansConfig.java
+++ b/view/src/main/java/org/xcolab/view/config/spring/beans/WebSecurityBeansConfig.java
@@ -15,6 +15,7 @@ import org.xcolab.view.auth.AuthenticationService;
 import org.xcolab.view.auth.handlers.AuthenticationSuccessHandler;
 import org.xcolab.view.auth.login.spring.MemberDetailsService;
 import org.xcolab.view.config.spring.properties.WebProperties;
+import org.xcolab.view.pages.redballon.utils.BalloonService;
 
 import java.util.UUID;
 
@@ -61,8 +62,8 @@ public class WebSecurityBeansConfig {
 
     @Bean
     public AuthenticationSuccessHandler authenticationSuccessHandler(
-            AuthenticationService authenticationService) {
+            AuthenticationService authenticationService, BalloonService balloonService) {
         final boolean allowLogin = webProperties.getGuestAccess().isAllowLogin();
-        return new AuthenticationSuccessHandler(authenticationService, allowLogin);
+        return new AuthenticationSuccessHandler(authenticationService, balloonService, allowLogin);
     }
 }

--- a/view/src/main/java/org/xcolab/view/pages/loginregister/LoginRegisterService.java
+++ b/view/src/main/java/org/xcolab/view/pages/loginregister/LoginRegisterService.java
@@ -29,7 +29,7 @@ import org.xcolab.util.html.HtmlUtil;
 import org.xcolab.view.auth.AuthenticationService;
 import org.xcolab.view.auth.handlers.AuthenticationSuccessHandler;
 import org.xcolab.view.pages.loginregister.singlesignon.SSOKeys;
-import org.xcolab.view.pages.redballon.utils.BalloonCookie;
+import org.xcolab.view.pages.redballoon.utils.BalloonCookie;
 import org.xcolab.view.util.entity.HttpUtils;
 
 import java.io.IOException;

--- a/view/src/main/java/org/xcolab/view/pages/loginregister/LoginRegisterService.java
+++ b/view/src/main/java/org/xcolab/view/pages/loginregister/LoginRegisterService.java
@@ -37,7 +37,6 @@ import java.sql.Timestamp;
 import java.util.Date;
 import java.util.Optional;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -214,7 +213,7 @@ public class LoginRegisterService {
             Authentication authentication = authenticationService
                     .authenticate(request, response, member);
             authenticationSuccessHandler.onAuthenticationSuccess(request, response, authentication);
-        } catch (ServletException | IOException e) {
+        } catch (IOException e) {
             authenticationService.logout(request, response);
             throw new InternalException(e);
         }

--- a/view/src/main/java/org/xcolab/view/pages/profile/view/UserProfileController.java
+++ b/view/src/main/java/org/xcolab/view/pages/profile/view/UserProfileController.java
@@ -41,7 +41,7 @@ import org.xcolab.view.pages.profile.beans.NewsletterBean;
 import org.xcolab.view.pages.profile.beans.UserBean;
 import org.xcolab.view.pages.profile.utils.UserProfilePermissions;
 import org.xcolab.view.pages.profile.wrappers.UserProfileWrapper;
-import org.xcolab.view.pages.redballon.utils.BalloonService;
+import org.xcolab.view.pages.redballoon.utils.BalloonService;
 import org.xcolab.view.util.entity.flash.AlertMessage;
 import org.xcolab.view.util.entity.flash.ErrorMessage;
 

--- a/view/src/main/java/org/xcolab/view/pages/redballon/utils/BalloonService.java
+++ b/view/src/main/java/org/xcolab/view/pages/redballon/utils/BalloonService.java
@@ -1,6 +1,8 @@
 package org.xcolab.view.pages.redballon.utils;
 
 import org.apache.commons.lang3.RandomUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -36,6 +38,8 @@ import static org.xcolab.util.http.exceptions.ExceptionUtils.getOptional;
 
 @Service
 public class BalloonService {
+
+    private static final Logger _log = LoggerFactory.getLogger(BalloonService.class);
 
     private static final String URL_PLACEHOLDER = "URLPLACEHOLDER";
 
@@ -151,6 +155,22 @@ public class BalloonService {
                         request.getHeader(HttpHeaders.USER_AGENT));
         request.setAttribute(NEW_BALLOON_USER_TRACKING_ATTRIBUTE, but);
         return but;
+    }
+
+    public void associateBalloonTrackingWithUser(HttpServletRequest request, Member member) {
+        Optional<BalloonCookie> balloonCookieOpt = BalloonCookie.from(request.getCookies());
+        if (balloonCookieOpt.isPresent()) {
+            final BalloonCookie balloonCookie = balloonCookieOpt.get();
+            try {
+                BalloonUserTracking but =
+                        BalloonsClient.getBalloonUserTracking(balloonCookie.getUuid());
+                if (but != null) {
+                    but.updateUserIdAndEmailIfEmpty(member.getId_(), member.getEmailAddress());
+                }
+            } catch (BalloonUserTrackingNotFoundException e) {
+                _log.error("Invalid UUID: {}", balloonCookie);
+            }
+        }
     }
 
     private BalloonUserTracking getBalloonUserTrackingFromCookie(BalloonCookie cookie) {

--- a/view/src/main/java/org/xcolab/view/pages/redballoon/utils/BalloonCookie.java
+++ b/view/src/main/java/org/xcolab/view/pages/redballoon/utils/BalloonCookie.java
@@ -1,4 +1,4 @@
-package org.xcolab.view.pages.redballon.utils;
+package org.xcolab.view.pages.redballoon.utils;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/view/src/main/java/org/xcolab/view/pages/redballoon/utils/BalloonService.java
+++ b/view/src/main/java/org/xcolab/view/pages/redballoon/utils/BalloonService.java
@@ -1,4 +1,4 @@
-package org.xcolab.view.pages.redballon.utils;
+package org.xcolab.view.pages.redballoon.utils;
 
 import org.apache.commons.lang3.RandomUtils;
 import org.slf4j.Logger;

--- a/view/src/main/java/org/xcolab/view/pages/redballoon/web/BalloonController.java
+++ b/view/src/main/java/org/xcolab/view/pages/redballoon/web/BalloonController.java
@@ -1,4 +1,4 @@
-package org.xcolab.view.pages.redballon.web;
+package org.xcolab.view.pages.redballoon.web;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,8 +23,8 @@ import org.xcolab.client.balloons.pojo.BalloonUserTracking;
 import org.xcolab.client.members.pojo.Member;
 import org.xcolab.entity.utils.LinkUtils;
 import org.xcolab.util.exceptions.ReferenceResolutionException;
-import org.xcolab.view.pages.redballon.utils.BalloonService;
-import org.xcolab.view.pages.redballon.web.beans.UserEmailBean;
+import org.xcolab.view.pages.redballoon.utils.BalloonService;
+import org.xcolab.view.pages.redballoon.web.beans.UserEmailBean;
 
 import java.sql.Timestamp;
 import java.util.Date;

--- a/view/src/main/java/org/xcolab/view/pages/redballoon/web/beans/UserEmailBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/redballoon/web/beans/UserEmailBean.java
@@ -1,4 +1,4 @@
-package org.xcolab.view.pages.redballon.web.beans;
+package org.xcolab.view.pages.redballoon.web.beans;
 
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotBlank;

--- a/view/src/test/java/org/xcolab/view/pages/loginregister/ForgotPasswordControllerTest.java
+++ b/view/src/test/java/org/xcolab/view/pages/loginregister/ForgotPasswordControllerTest.java
@@ -28,8 +28,7 @@ import org.xcolab.view.util.clienthelpers.AdminClientMockerHelper;
 import org.xcolab.view.util.clienthelpers.EmailTemplateClientMockerHelper;
 import org.xcolab.view.util.clienthelpers.MembersClientMockerHelper;
 
-import static org.springframework.security.test.web.servlet.request
-        .SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 
@@ -43,6 +42,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @ComponentScan("org.xcolab.view.pages.proposals.interceptors")
 @ComponentScan("org.xcolab.view.pages.loginregister")
 @ComponentScan("org.xcolab.view.pages.proposals.utils.context")
+@ComponentScan("org.xcolab.view.pages.redballoon")
 @ComponentScan("org.xcolab.view.config")
 @ComponentScan("org.xcolab.view.i18n")
 @TestPropertySource(
@@ -116,3 +116,5 @@ public class ForgotPasswordControllerTest {
     }
 
 }
+
+

--- a/view/src/test/java/org/xcolab/view/pages/loginregister/LoginRegisterControllerTest.java
+++ b/view/src/test/java/org/xcolab/view/pages/loginregister/LoginRegisterControllerTest.java
@@ -55,6 +55,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ComponentScan("org.xcolab.view.pages.proposals.interceptors")
 @ComponentScan("org.xcolab.view.pages.proposals.utils.context")
 @ComponentScan("org.xcolab.view.pages.loginregister")
+@ComponentScan("org.xcolab.view.pages.redballoon")
 @ComponentScan("org.xcolab.view.config")
 @ComponentScan("org.xcolab.view.i18n")
 


### PR DESCRIPTION
This PR adds a call to the AuthenticationSuccessHandler when authenticating programmatically via the AuthenticationService. It includes some small refactoring to allow for the success handler not to redirect and to allow for the circular dependency between the success handler and service (there's a separate task to rethink this structure).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/51)
<!-- Reviewable:end -->
