### PR TITLE
[COLAB-2375] share message link

### DIFF
--- a/view/src/main/webapp/WEB-INF/jsp/proposals/proposalDetails/proposalSummary.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/proposals/proposalDetails/proposalSummary.jspx
@@ -247,6 +247,12 @@
         </script>
     </c:if>
 
-    <xcolab:sendMessageModal subject="I want to share a ${contestType.proposalName} with you!" content='Check out the ${contestType.proposalName} "${proposal.name}" in the "${contest.contestName}" ${contestType.contestName}.' />
+    <c:set var="shareMessageBody">
+        Check out the ${contestType.proposalNameLowercase} &quot;<a href="${proposal.proposalUrl}">${proposal.name}</a>&quot;
+        in the &quot;<a href="${contest.contestUrl}">${contest.contestShortNameWithEndYear}</a>&quot; ${contestType.contestNameLowercase}.
+    </c:set>
+
+    <xcolab:sendMessageModal subject="I want to share a ${contestType.proposalNameLowercase} with you!"
+                             content="${shareMessageBody}" />
 
 </jsp:root>


### PR DESCRIPTION
This PR adds links to the share message for proposals.

Additional changes:
* Fix display of contest name (use short name instead of contest question)
* Change mentions of "proposal" and "contest" to lower in line with our capitalization guidelines

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/55)
<!-- Reviewable:end -->
