### PR TITLE
[COLAB-2361] csvs cut off

### DIFF
--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/AdminTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/AdminTabController.java
@@ -148,10 +148,11 @@ public class AdminTabController extends AbstractTabController {
             return;
         }
 
-        VoteCsvWriter csvConverter = new VoteCsvWriter(response);
-        votingReportBean.getVotingPhaseIds().stream()
-                .map(ProposalMemberRatingClientUtil::getProposalVotesInPhase)
-                .forEach(csvConverter::addVotes);
+        try (VoteCsvWriter csvWriter = new VoteCsvWriter(response)) {
+            votingReportBean.getVotingPhaseIds().stream()
+                    .map(ProposalMemberRatingClientUtil::getProposalVotesInPhase)
+                    .forEach(csvWriter::addVotes);
+        }
     }
 
     @PostMapping("tab/ADMIN/exportActivities")
@@ -162,9 +163,10 @@ public class AdminTabController extends AbstractTabController {
             return;
         }
 
-        ActivityCsvWriter csvWriter = new ActivityCsvWriter(response, activityEntryHelper);
-        ActivitiesClientUtil.getActivityEntries(0, Integer.MAX_VALUE, null, null)
-                .forEach(csvWriter::writeActivity);
+        try (ActivityCsvWriter csvWriter = new ActivityCsvWriter(response, activityEntryHelper)) {
+            ActivitiesClientUtil.getActivityEntries(0, Integer.MAX_VALUE, null, null)
+                    .forEach(csvWriter::writeActivity);
+        }
     }
 
     @PostMapping("tab/ADMIN/batchRegister")

--- a/view/src/main/java/org/xcolab/view/pages/members/users/MembersController.java
+++ b/view/src/main/java/org/xcolab/view/pages/members/users/MembersController.java
@@ -178,10 +178,11 @@ public class MembersController {
         MembersPermissions membersPermissions = new MembersPermissions(request);
 
         if (membersPermissions.getCanDownloadMemberList()) {
-            MemberListCsvWriter csvWriter = new MemberListCsvWriter(response);
-            List<Member> memberList = MembersClient.listMembers(null, null, null,
-                            null, true, 0, Integer.MAX_VALUE);
-            csvWriter.writeMembers(removeDuplicates(memberList));
+            try (MemberListCsvWriter csvWriter = new MemberListCsvWriter(response)) {
+                List<Member> memberList = MembersClient.listMembers(null, null,
+                        null, null, true, 0, Integer.MAX_VALUE);
+                csvWriter.writeMembers(removeDuplicates(memberList));
+            }
         }
     }
     private List<Member>  removeDuplicates(List<Member> members) {

--- a/view/src/main/java/org/xcolab/view/util/CsvResponseWriter.java
+++ b/view/src/main/java/org/xcolab/view/util/CsvResponseWriter.java
@@ -14,7 +14,6 @@ import java.text.Normalizer;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -57,7 +56,7 @@ public abstract class CsvResponseWriter implements Closeable {
         try {
             // Excel needs this as different regional versions except different separators
             outWriter.append(EXCEL_SEPARATOR_META_DATA);
-            csvWriter.writeNext(headerRow.toArray(new String[headerRow.size()]));
+            csvWriter.writeNext(cleanRow(headerRow));
         } catch (IOException e) {
             // make sure the streams get closed if we get an exception while writing
             csvWriter.close();
@@ -67,11 +66,7 @@ public abstract class CsvResponseWriter implements Closeable {
 
     protected void writeRow(List<String> cols) {
         checkLength(cols);
-        final String[] colArray = cols.stream()
-                .map(this::clean)
-                .collect(Collectors.toList())
-                .toArray(new String[numColumns]);
-        csvWriter.writeNext(colArray);
+        csvWriter.writeNext(cleanRow(cols));
     }
 
     private void checkLength(List<String> cols) {
@@ -79,6 +74,12 @@ public abstract class CsvResponseWriter implements Closeable {
             throw new IllegalArgumentException(
                     "Illegal column length: " + cols.size() + " - expected " + numColumns);
         }
+    }
+
+    private String[] cleanRow(List<String> row) {
+        return row.stream()
+                .map(this::clean)
+                .toArray(String[]::new);
     }
 
     private String clean(String string) {

--- a/view/src/main/java/org/xcolab/view/widgets/feeds/FeedsDumpGeneratingController.java
+++ b/view/src/main/java/org/xcolab/view/widgets/feeds/FeedsDumpGeneratingController.java
@@ -29,10 +29,11 @@ public class FeedsDumpGeneratingController {
     public void showFeed(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
 
-        ActivityCsvWriter
-                csvWriter = new ActivityCsvWriter(response, activityEntryHelper);
         final List<ActivityEntry> activityEntries = ActivitiesClientUtil
                 .getActivityEntries(0, Integer.MAX_VALUE, null, null);
-        csvWriter.writeActivities(activityEntries);
+
+        try (ActivityCsvWriter csvWriter = new ActivityCsvWriter(response, activityEntryHelper)) {
+            csvWriter.writeActivities(activityEntries);
+        }
     }
 }


### PR DESCRIPTION
This PR ensures that all CsvWriters are being closed as otherwise they might not flush all content to the response before it is sent. Additionally, extracts a cleanRow method and applies it to the header row as well to make sure no illegal characters or unquoted strings are written.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/56)
<!-- Reviewable:end -->
