### PR TITLE
[COLAB-2379] Refactor proposal sorting

### DIFF
--- a/view/src/main/java/org/xcolab/view/pages/proposals/utils/ProposalSortColumn.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/utils/ProposalSortColumn.java
@@ -1,10 +1,11 @@
 package org.xcolab.view.pages.proposals.utils;
 
 import org.xcolab.client.proposals.pojo.Proposal;
+import org.xcolab.client.proposals.pojo.proposals.ProposalRibbon;
 
 import java.util.Comparator;
 
-public enum ProposalsColumn {
+public enum ProposalSortColumn {
     NAME(Comparator.comparing(o -> o.getName().toLowerCase())),
     AUTHOR(Comparator.comparing(o -> o.getAuthorName().toLowerCase())),
     SUPPORTERS((o1, o2) -> (int) (o1.getSupportersCount() - o2.getSupportersCount())),
@@ -32,11 +33,22 @@ public enum ProposalsColumn {
         } else {
             return o2.isOpen() ? 1 : 0;
         }
+    }),
+    RIBBONS((o1, o2) -> {
+        final ProposalRibbon ribbon1 = o1.getRibbonWrapper();
+        final ProposalRibbon ribbon2 = o2.getRibbonWrapper();
+
+        int sortOrderDiff = ribbon1.getSortOrder() - ribbon2.getSortOrder();
+        if (sortOrderDiff != 0) {
+            return sortOrderDiff;
+        }
+
+        return ribbon1.getRibbon() - ribbon2.getRibbon();
     });
     
     private final Comparator<Proposal> proposalsComparator;
     
-    ProposalsColumn(Comparator<Proposal> comparator) {
+    ProposalSortColumn(Comparator<Proposal> comparator) {
         proposalsComparator = comparator;
     }
 

--- a/view/src/main/java/org/xcolab/view/pages/proposals/view/contest/ContestProposalsController.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/view/contest/ContestProposalsController.java
@@ -24,7 +24,7 @@ import org.xcolab.view.pages.proposals.utils.context.ClientHelper;
 import org.xcolab.view.pages.proposals.utils.context.ProposalContext;
 import org.xcolab.view.pages.proposals.view.proposal.BaseProposalsController;
 import org.xcolab.view.pages.proposals.wrappers.ProposalJudgeWrapper;
-import org.xcolab.view.pages.proposals.wrappers.ProposalsSortFilterBean;
+import org.xcolab.view.pages.proposals.wrappers.SortedProposalList;
 import org.xcolab.view.util.entity.enums.MemberRole;
 import org.xcolab.view.util.pagination.SortFilterPage;
 
@@ -106,7 +106,7 @@ public class ContestProposalsController extends BaseProposalsController {
 
         model.addAttribute("sortFilterPage", sortFilterPage);
         model.addAttribute("proposals",
-            new ProposalsSortFilterBean(proposals, sortFilterPage));
+            new SortedProposalList(proposals, sortFilterPage));
         model.addAttribute("showCountdown",
                 ConfigurationAttributeKey.SHOW_CONTEST_COUNTDOWN.get());
         model.addAttribute("defaultTimeZoneId",

--- a/view/src/main/java/org/xcolab/view/pages/proposals/wrappers/ProposalsSortFilterBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/wrappers/ProposalsSortFilterBean.java
@@ -3,118 +3,73 @@ package org.xcolab.view.pages.proposals.wrappers;
 import org.apache.commons.lang3.StringUtils;
 
 import org.xcolab.client.proposals.pojo.Proposal;
-import org.xcolab.client.proposals.pojo.proposals.ProposalRibbon;
-import org.xcolab.view.pages.proposals.utils.ProposalsColumn;
+import org.xcolab.view.pages.proposals.utils.ProposalSortColumn;
 import org.xcolab.view.util.pagination.SortFilterPage;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
 public class ProposalsSortFilterBean {
 
-    private final List<Proposal> proposals;
-    private Comparator<Proposal> proposalComparator;
-    
-    private List<Proposal> proposalsWithRibbons = new ArrayList<>();
-    private List<Proposal> proposalsNormal = new ArrayList<>();
+    private final List<Proposal> proposalsWithRibbons = new ArrayList<>();
+    private final List<Proposal> proposalsWithoutRibbons = new ArrayList<>();
 
     public ProposalsSortFilterBean(List<Proposal> proposals, final SortFilterPage sortFilterPage) {
-        super();
-        this.proposals = proposals;
-
         if (sortFilterPage == null) {
-            throw new IllegalArgumentException("sortFilterPage was null");
+            throw new IllegalArgumentException("SortFilterPage can't be null");
         }
-        
-        // sort proposals
-        if (StringUtils.isNotBlank(sortFilterPage.getSortColumn())) {
-            switch (sortFilterPage.getSortColumn().toUpperCase()) {
-                case "NAME":
-                    proposalComparator = ProposalsColumn.NAME.getComparator(); break;
-                case "AUTHOR":
-                    proposalComparator = ProposalsColumn.AUTHOR.getComparator(); break;
-                case "COMMENTS":
-                    proposalComparator = ProposalsColumn.COMMENTS.getComparator(); break;
-                case "CONTRIBUTORS":
-                    proposalComparator = ProposalsColumn.CONTRIBUTORS.getComparator(); break;
-                case "MODIFIED":
-                    proposalComparator = ProposalsColumn.MODIFIED.getComparator(); break;
-                case "SUPPORTERS":
-                    proposalComparator = ProposalsColumn.SUPPORTERS.getComparator(); break;
-                case "VOTES":
-                    proposalComparator = ProposalsColumn.VOTES.getComparator(); break;
-                case "JUDGESTATUS":
-                    proposalComparator = ProposalsColumn.JUDGESTATUS.getComparator(); break;
-                case "SCREENINGSTATUS":
-                    proposalComparator = ProposalsColumn.SCREENINGSTATUS.getComparator(); break;
-                case "IAFSTATUS":
-                    proposalComparator = ProposalsColumn.IAFSTATUS.getComparator(); break;
-                case "OVERALLSTATUS":
-                    proposalComparator = ProposalsColumn.OVERALLSTATUS.getComparator(); break;
-                default:
-                    throw new IllegalArgumentException("Unknown sort column");
+
+        initProposalLists(proposals);
+        sortProposalLists(sortFilterPage);
+    }
+
+    private void initProposalLists(List<Proposal> proposals) {
+        for (Proposal contest : proposals) {
+            if (contest.getRibbonWrapper().getRibbon() > 0) {
+                proposalsWithRibbons.add(contest);
+            } else {
+                proposalsWithoutRibbons.add(contest);
             }
         }
-        
-        if (StringUtils.isNotBlank(sortFilterPage.getSortColumn())) {
-            proposalComparator = ProposalsColumn.valueOf(sortFilterPage.getSortColumn()).getComparator();
+    }
+
+    private void sortProposalLists(SortFilterPage sortFilterPage) {
+        final String sortColumn = sortFilterPage.getSortColumn();
+
+        Comparator<Proposal> proposalComparator;
+        boolean sortColumnSet = StringUtils.isBlank(sortColumn);
+        if (!sortColumnSet) {
+            final ProposalSortColumn proposalsColumn = ProposalSortColumn.valueOf(sortColumn);
+            proposalComparator = sortFilterPage.isSortAscending() ? proposalsColumn.getComparator()
+                    : proposalsColumn.getComparator().reversed();
+        } else {
+            proposalComparator = ProposalSortColumn.MODIFIED.getComparator().reversed();
         }
-        else {
-            proposalComparator = ProposalsColumn.MODIFIED.getComparator();
-            sortFilterPage.setSortAscending(!sortFilterPage.isSortAscending()); // default sort is date DESC
-        }
 
-        if (this.proposals != null && !this.proposals.isEmpty()) {
-
-            this.proposals.sort((o1, o2) -> {
-                if (StringUtils.isBlank(sortFilterPage.getSortColumn())) {
-                    final ProposalRibbon ribbon1 = o1.getRibbonWrapper();
-                    final ProposalRibbon ribbon2 = o2.getRibbonWrapper();
-
-                    int sortOrderDiff = ribbon1.getSortOrder() - ribbon2.getSortOrder();
-                    if (sortOrderDiff != 0) {
-                        return sortOrderDiff;
-                    }
-
-                    int ribbonDiff = ribbon1.getRibbon() - ribbon2.getRibbon();
-                    if (ribbonDiff != 0) {
-                        return ribbonDiff;
-                    }
-                }
-                if (sortFilterPage.isSortAscending()) {
-                    return proposalComparator.compare(o1, o2);
-                }
-                return proposalComparator.compare(o2, o1);
-            });
-
-            for (Proposal contest : this.proposals) {
-                if (contest.getRibbonWrapper().getRibbon() > 0) {
-                    proposalsWithRibbons.add(contest);
-                } else {
-                    proposalsNormal.add(contest);
-                }
-            }
-        }
+        proposalsWithRibbons.sort(sortColumnSet ? proposalComparator
+                : ProposalSortColumn.RIBBONS.getComparator().thenComparing(proposalComparator));
+        proposalsWithoutRibbons.sort(proposalComparator);
     }
 
     public List<Proposal> getProposalsWithRibbons() {
-        return proposalsWithRibbons;
+        return Collections.unmodifiableList(proposalsWithRibbons);
     }
 
-    public void setProposalsWithRibbons(List<Proposal> proposalsWithRibbons) {
-        this.proposalsWithRibbons = proposalsWithRibbons;
+    public List<Proposal> getProposalsWithoutRibbons() {
+        return Collections.unmodifiableList(proposalsWithoutRibbons);
     }
 
-    public List<Proposal> getProposalsNormal() {
-        return proposalsNormal;
+    public int getTotalSize() {
+        return getSizeWithRibbons() + getSizeWithoutRibbons();
     }
 
-    public void setProposalsNormal(List<Proposal> proposalsNormal) {
-        this.proposalsNormal = proposalsNormal;
+    public int getSizeWithRibbons() {
+        return proposalsWithRibbons.size();
     }
 
-    public List<Proposal> getProposals() {
-        return proposals;
+    public int getSizeWithoutRibbons() {
+        return proposalsWithoutRibbons.size();
     }
 }

--- a/view/src/main/java/org/xcolab/view/pages/proposals/wrappers/SortedProposalList.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/wrappers/SortedProposalList.java
@@ -41,9 +41,7 @@ public class SortedProposalList {
         Comparator<Proposal> proposalComparator;
         boolean sortColumnSet = StringUtils.isBlank(sortColumn);
         if (!sortColumnSet) {
-            final ProposalSortColumn proposalsColumn = ProposalSortColumn.valueOf(sortColumn);
-            proposalComparator = sortFilterPage.isSortAscending() ? proposalsColumn.getComparator()
-                    : proposalsColumn.getComparator().reversed();
+            proposalComparator = getComparator(sortColumn, sortFilterPage.isSortAscending());
         } else {
             proposalComparator = ProposalSortColumn.MODIFIED.getComparator().reversed();
         }
@@ -51,6 +49,12 @@ public class SortedProposalList {
         proposalsWithRibbons.sort(sortColumnSet ? proposalComparator
                 : ProposalSortColumn.RIBBONS.getComparator().thenComparing(proposalComparator));
         proposalsWithoutRibbons.sort(proposalComparator);
+    }
+
+    private Comparator<Proposal> getComparator(String sortColumn, boolean isSortAscending) {
+        final ProposalSortColumn proposalsColumn = ProposalSortColumn.valueOf(sortColumn);
+        return isSortAscending ? proposalsColumn.getComparator()
+                : proposalsColumn.getComparator().reversed();
     }
 
     public List<Proposal> getProposalsWithRibbons() {

--- a/view/src/main/java/org/xcolab/view/pages/proposals/wrappers/SortedProposalList.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/wrappers/SortedProposalList.java
@@ -11,12 +11,12 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-public class ProposalsSortFilterBean {
+public class SortedProposalList {
 
     private final List<Proposal> proposalsWithRibbons = new ArrayList<>();
     private final List<Proposal> proposalsWithoutRibbons = new ArrayList<>();
 
-    public ProposalsSortFilterBean(List<Proposal> proposals, final SortFilterPage sortFilterPage) {
+    public SortedProposalList(List<Proposal> proposals, final SortFilterPage sortFilterPage) {
         if (sortFilterPage == null) {
             throw new IllegalArgumentException("SortFilterPage can't be null");
         }

--- a/view/src/main/java/org/xcolab/view/pages/proposals/wrappers/SortedProposalList.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/wrappers/SortedProposalList.java
@@ -26,11 +26,11 @@ public class SortedProposalList {
     }
 
     private void initProposalLists(List<Proposal> proposals) {
-        for (Proposal contest : proposals) {
-            if (contest.getRibbonWrapper().getRibbon() > 0) {
-                proposalsWithRibbons.add(contest);
+        for (Proposal proposal : proposals) {
+            if (proposal.getRibbonWrapper().getRibbon() > 0) {
+                proposalsWithRibbons.add(proposal);
             } else {
-                proposalsWithoutRibbons.add(contest);
+                proposalsWithoutRibbons.add(proposal);
             }
         }
     }

--- a/view/src/main/webapp/WEB-INF/jsp/proposals/contestProposals.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/proposals/contestProposals.jspx
@@ -15,8 +15,8 @@
 
         <jsp:directive.include file="./init_contest.jspx"/>
 
-        <jsp:useBean id="proposals" type="org.xcolab.view.pages.proposals.wrappers.ProposalsSortFilterBean" scope="request" />
-        <jsp:useBean id="sortFilterPage" type="org.xcolab.view.util.pagination.SortFilterPage" scope="request" />
+        <!--@elvariable id="proposals" type="org.xcolab.view.pages.proposals.wrappers.ProposalsSortFilterBean"-->
+        <!--@elvariable id="sortFilterPage" type="org.xcolab.view.util.pagination.SortFilterPage"-->
 
         <c:set var="showJudgingStatus" scope="request"
                value="${proposalsPermissions.canJudgeActions or proposalsPermissions.canFellowActions}"/>
@@ -37,9 +37,9 @@
             </div>
             <div class="c-Headline c-Headline__subhead">
                 <h2>
-                    <span>${fn:length(proposals.proposals)}</span>
+                    <span>${proposals.totalSize}</span>
                     <c:choose>
-                        <c:when test="${fn:length(proposals.proposals) == 1}">
+                        <c:when test="${proposals.totalSize == 1}">
                             &#160;${contestType.proposalName}
                         </c:when>
                         <c:otherwise>
@@ -200,7 +200,7 @@
                 </thead>
                 <tbody>
                     <proposalsPortlet:proposalsList proposals="${proposals.proposalsWithRibbons }" showShadebar="true"/>
-                    <proposalsPortlet:proposalsList proposals="${proposals.proposalsNormal }" showShadebar="${fn:length(proposals.proposalsWithRibbons) > 0 and not contest.hideRibbons}"/>
+                    <proposalsPortlet:proposalsList proposals="${proposals.proposalsWithoutRibbons }" showShadebar="${proposals.sizeWithRibbons > 0 and not contest.hideRibbons}"/>
                 </tbody>
             </table>
         </div>

--- a/view/src/main/webapp/WEB-INF/jsp/proposals/contestProposals.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/proposals/contestProposals.jspx
@@ -15,7 +15,7 @@
 
         <jsp:directive.include file="./init_contest.jspx"/>
 
-        <!--@elvariable id="proposals" type="org.xcolab.view.pages.proposals.wrappers.ProposalsSortFilterBean"-->
+        <!--@elvariable id="proposals" type="org.xcolab.view.pages.proposals.wrappers.SortedProposalList"-->
         <!--@elvariable id="sortFilterPage" type="org.xcolab.view.util.pagination.SortFilterPage"-->
 
         <c:set var="showJudgingStatus" scope="request"


### PR DESCRIPTION
This PR simplifies the `ProposalsSortFilterBean` (now `SortedProposalList`) class, which did not need to be mutable and had some duplicate code (the comparator was initialized twice, overwriting the first initialization).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/57)
<!-- Reviewable:end -->
