### PR TITLE
[COLAB-2420] Fix permissions for reopening proposals

### DIFF
--- a/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextHelper.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextHelper.java
@@ -134,18 +134,19 @@ public class ProposalContextHelper {
         final ProposalClient proposalClient = clientHelper.getProposalClient();
 
         ContestPhase contestPhase;
+        final long contestId = contest.getContestPK();
         if (givenPhaseId > 0) {
             contestPhase = contestClient.getContestPhase(givenPhaseId);
-        } else if (proposal != null) {
+        } else if (proposal != null && proposal.getContest().getContestPK() == contestId) {
             contestPhase = proposalClient.getLatestContestPhaseInProposal(proposal.getProposalId());
         } else {
-            contestPhase = contestClient.getActivePhase(contest.getContestPK());
+            contestPhase = contestClient.getActivePhase(contestId);
         }
 
         if (contestPhase == null) {
             throw ReferenceResolutionException
                     .toObject(ContestPhase.class, "")
-                    .fromObject(Contest.class, contest.getContestPK());
+                    .fromObject(Contest.class, contestId);
         }
         return contestPhase;
     }

--- a/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextImpl.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextImpl.java
@@ -63,7 +63,8 @@ public class ProposalContextImpl implements ProposalContext {
                 contestPhase = contextHelper.getContestPhase(contest, proposal);
                 if (proposal != null) {
                     proposal2Phase = contextHelper.getProposal2Phase(contestPhase);
-                    if (proposal2Phase == null && request.getParameter("isMove") == null) {
+                    final boolean isMove = request.getParameter("moveType") != null;
+                    if (proposal2Phase == null && !isMove) {
                         if (contextHelper.getGivenPhaseId() > 0) {
                             throw new InvalidAccessException();
                         }

--- a/view/src/main/webapp/WEB-INF/jsp/proposals/proposalDetails.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/proposals/proposalDetails.jspx
@@ -8,6 +8,8 @@
           xmlns:spring="http://www.springframework.org/tags">
 
     <jsp:directive.page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"/>
+
+    <!--@elvariable id="proposal" type="org.xcolab.client.proposals.pojo.Proposal"-->
     <c:choose>
         <c:when test='${proposal.imageId > 0}'>
             <c:set var="proposalOpenGraphImage" value="${contest.proposalLogoPath}image/proposal/${proposal.imageId}"/>


### PR DESCRIPTION
This PR fixes a permission problem when reopening a proposal in a new contest. The permissions class was using the ContestPhase from the source contest to evaluate permissions to create proposals in the new contest, which prevented reopening proposals from closed contests for non-admins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/69)
<!-- Reviewable:end -->
