### PR TITLE
[COLAB-2408] Fix section copying when moving proposals

### DIFF
--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/pojo/Proposal.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/pojo/Proposal.java
@@ -141,7 +141,11 @@ public class Proposal extends AbstractProposal {
         this(proposal, proposal.getCurrentVersion(), null, contestPhase, proposal2Phase);
     }
 
-    public Proposal(Proposal proposal, int version, Contest contest,
+    public Proposal(Proposal proposal, Contest contest) {
+        this(proposal, null, contest, null, null);
+    }
+
+    public Proposal(Proposal proposal, Integer version, Contest contest,
             ContestPhase contestPhase, Proposal2Phase proposal2Phase) {
         super(proposal);
 
@@ -159,7 +163,8 @@ public class Proposal extends AbstractProposal {
 
         proposalContestPhaseAttributeHelper =
                 new ProposalContestPhaseAttributeHelper(this, this.contestPhase);
-        proposalAttributeHelper = new ProposalAttributeHelper(this, version,
+        final int currentVersion = version != null ? version : proposal.getVersion();
+        proposalAttributeHelper = new ProposalAttributeHelper(this, currentVersion,
                 clients.proposalAttribute);
         unversionedAttributeHelper = new ProposalUnversionedAttributeHelper(this,
                 clients.proposalAttribute);

--- a/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextHelper.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextHelper.java
@@ -163,16 +163,16 @@ public class ProposalContextHelper {
 
     public Proposal getProposal(Contest contest) throws InvalidAccessException {
         final ProposalClient proposalClient = clientHelper.getProposalClient();
+        Proposal proposal = null;
         if (givenProposalId > 0) {
             try {
-                Proposal proposal = proposalClient.getProposal(givenProposalId);
-                return new Proposal(proposal, contest);
+                proposal = new Proposal(proposalClient.getProposal(givenProposalId), contest);
             } catch (ProposalNotFoundException e) {
                 log.debug("Invalid proposal supplied: givenProposalId = {}", givenProposalId);
                 throw new InvalidAccessException();
             }
         }
-        return null;
+        return proposal;
     }
 
     public Proposal getProposalWrapper(Proposal proposal, Proposal2Phase proposal2Phase,

--- a/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextHelper.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextHelper.java
@@ -161,18 +161,18 @@ public class ProposalContextHelper {
         }
     }
 
-    public Proposal getProposal() throws InvalidAccessException {
+    public Proposal getProposal(Contest contest) throws InvalidAccessException {
         final ProposalClient proposalClient = clientHelper.getProposalClient();
-        Proposal proposal = null;
         if (givenProposalId > 0) {
             try {
-                proposal = proposalClient.getProposal(givenProposalId);
+                Proposal proposal = proposalClient.getProposal(givenProposalId);
+                return new Proposal(proposal, contest);
             } catch (ProposalNotFoundException e) {
                 log.debug("Invalid proposal supplied: givenProposalId = {}", givenProposalId);
                 throw new InvalidAccessException();
             }
         }
-        return proposal;
+        return null;
     }
 
     public Proposal getProposalWrapper(Proposal proposal, Proposal2Phase proposal2Phase,

--- a/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextImpl.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextImpl.java
@@ -55,7 +55,7 @@ public class ProposalContextImpl implements ProposalContext {
 
         try {
             contest = contextHelper.getContest();
-            proposal = contextHelper.getProposal();
+            proposal = contextHelper.getProposal(contest);
             clientHelper = contextHelper.getClientHelper();
 
             if (contest != null) {

--- a/view/src/main/java/org/xcolab/view/pages/proposals/view/proposal/tabs/ProposalDescriptionTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/view/proposal/tabs/ProposalDescriptionTabController.java
@@ -20,7 +20,6 @@ import org.xcolab.client.contest.pojo.templates.PlanSectionDefinition;
 import org.xcolab.client.flagging.FlaggingClient;
 import org.xcolab.client.members.PlatformTeamsClient;
 import org.xcolab.client.members.pojo.Member;
-import org.xcolab.client.members.pojo.PlatformTeam;
 import org.xcolab.client.proposals.ProposalClient;
 import org.xcolab.client.proposals.ProposalMoveClient;
 import org.xcolab.client.proposals.pojo.ContestTypeProposal;
@@ -46,8 +45,6 @@ import org.xcolab.view.util.entity.flash.AlertMessage;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -127,7 +124,7 @@ public class ProposalDescriptionTabController extends BaseProposalTabController 
             updateProposalDetailsBean.setMoveToContestId(proposalContext.getContest().getContestPK());
 
             model.addAttribute("hasUnmappedSections",
-                    hasUnmappedSections(proposal, baseProposalWrapped));
+                    hasUnmappedSections(proposalContext.getContest(), baseProposalWrapped));
             model.addAttribute("baseProposal", baseProposalWrapped);
             model.addAttribute("baseContest", baseContest);
             model.addAttribute("isMove", true);
@@ -176,8 +173,8 @@ public class ProposalDescriptionTabController extends BaseProposalTabController 
         return "proposals/proposalDetails";
     }
 
-    private boolean hasUnmappedSections(Proposal proposalWrapped, Proposal baseProposalWrapped) {
-        Set<Long> newContestSections = proposalWrapped.getSections().stream()
+    private boolean hasUnmappedSections(Contest moveToContest, Proposal baseProposalWrapped) {
+        Set<Long> newContestSections = moveToContest.getSections().stream()
                 .map(PlanSectionDefinition::getSectionDefinitionId)
                 .collect(Collectors.toSet());
 


### PR DESCRIPTION
This PR fixes the proposal-contest mapping when copying a proposal. The context proposal did not previously reference the context contest (i.e. the target contest), but did instead reference the source contest. This lead to a problem with checking if the sections changed.

~Depends on #69.~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/70)
<!-- Reviewable:end -->
