### PR TITLE
[COLAB-2383] Remove end dates from schedules

### DIFF
--- a/sql/deployments/deployment-2017-11-15.sql
+++ b/sql/deployments/deployment-2017-11-15.sql
@@ -1,0 +1,28 @@
+SET @row_number1 = 0;
+SET @row_number2 = 0;
+UPDATE xcolab_ContestPhase
+JOIN (SELECT one.id_ AS id_, one.PhaseStartDate AS PhaseStartDate, one.PhaseEndDate AS oldPhaseEndDate, two.PhaseStartDate AS newPhaseEndDate
+      FROM
+      (SELECT *, @row_number1 := @row_number1 + 1 AS row_number
+      FROM (SELECT DISTINCT
+              id_,
+              PhaseStartDate,
+              PhaseEndDate
+            FROM xcolab_ContestSchedule
+              JOIN xcolab_ContestPhase ON contestScheduleId = id_
+            ORDER BY id_ ASC, PhaseStartDate ASC) AS _) AS one
+      LEFT JOIN
+      (SELECT *, @row_number2 := @row_number2 + 1 AS row_number
+      FROM (SELECT DISTINCT
+              id_,
+              PhaseStartDate,
+              PhaseEndDate
+            FROM xcolab_ContestSchedule
+              JOIN xcolab_ContestPhase ON contestScheduleId = id_
+            ORDER BY id_ ASC, PhaseStartDate ASC) AS _) AS two
+      ON one.row_number = two.row_number - 1 AND one.id_ = two.id_) AS r
+  ON (xcolab_ContestPhase.contestScheduleId = r.id_
+      AND xcolab_ContestPhase.PhaseStartDate = r.PhaseStartDate
+      AND xcolab_ContestPhase.PhaseEndDate = r.oldPhaseEndDate)
+SET xcolab_ContestPhase.PhaseEndDate = r.newPhaseEndDate
+WHERE xcolab_ContestPhase.PhaseEndDate IS NOT NULL;

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/SchedulesTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/SchedulesTabController.java
@@ -42,8 +42,7 @@ public class SchedulesTabController extends AbstractTabController {
             "This schedule is used in at least one contest that has already started. "
                     + "Please make sure you only change future phases.";
     private static final String SCHEDULE_CHANGE_INVALID_MESSAGE =
-            "This schedule is invalid. "
-                    + "Please make sure there is no gap or overlap between two adjacent phases";
+            "This schedule is invalid.";
 
     @ModelAttribute("currentTabWrapped")
     @Override

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/SchedulesTabController.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/controller/manager/SchedulesTabController.java
@@ -153,6 +153,8 @@ public class SchedulesTabController extends AbstractTabController {
             result.reject(CONTEST_SCHEDULE_BEAN_ATTRIBUTE_KEY, SCHEDULE_CHANGE_ERROR_MESSAGE);
         }
 
+        contestScheduleBean.setPhaseEndDates();
+
         if (!contestScheduleBean.isValidSchedule()) {
             result.reject(CONTEST_SCHEDULE_BEAN_ATTRIBUTE_KEY, SCHEDULE_CHANGE_INVALID_MESSAGE);
         }

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestScheduleBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestScheduleBean.java
@@ -118,6 +118,16 @@ public class ContestScheduleBean {
         return contestSchedule.isUsedInNonEmptyContest();
     }
 
+    public void setPhaseEndDates() {
+        ContestPhaseBean prevContestPhase = null;
+        for (ContestPhaseBean contestPhase : schedulePhases) {
+            if (prevContestPhase != null) {
+                prevContestPhase.setPhaseEndDate(contestPhase.getPhaseStartDate());
+            }
+            prevContestPhase = contestPhase;
+        }
+    }
+
     public boolean isValidSchedule() {
         boolean isValid = true;
         Date prevEndDate = null;

--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestScheduleBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/ContestScheduleBean.java
@@ -130,14 +130,21 @@ public class ContestScheduleBean {
 
     public boolean isValidSchedule() {
         boolean isValid = true;
-        Date prevEndDate = null;
+        ContestPhaseBean prevContestPhase = null;
         for (ContestPhaseBean contestPhase : schedulePhases) {
-            Date curStartDate = contestPhase.getPhaseStartDate();
-            if (prevEndDate != null && !curStartDate.equals(prevEndDate)) {
-                isValid = false;
-                break;
+            if (prevContestPhase != null) {
+                Date prevStartDate = prevContestPhase.getPhaseStartDate();
+                Date prevEndDate = prevContestPhase.getPhaseEndDate();
+                Date curStartDate = contestPhase.getPhaseStartDate();
+
+                if (prevStartDate != null && prevEndDate != null && curStartDate != null) {
+                    isValid &= prevStartDate.before(curStartDate);
+                    isValid &= prevEndDate.equals(curStartDate);
+                } else {
+                    isValid = false;
+                }
             }
-            prevEndDate = contestPhase.getPhaseEndDate();
+            prevContestPhase = contestPhase;
         }
         return isValid;
     }

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/schedulesTab.jspx
@@ -119,7 +119,6 @@
                             <th>Phase Type</th>
                             <!-- <th>Buffer</th> -->
                             <th>Start Date</th>
-                            <th>End Date</th>
                             <th>Autopromote</th>
                             <th>Fellow <br/>Screening</th>
                             <th><!-- --></th>
@@ -171,18 +170,6 @@
                                                 data-select-attribute="datetimepicker"
                                                 data-form-name="phaseStartDate"
                                                 readonly="${inputIsReadOnly}"
-                                            />
-
-                                </td>
-
-                                <td>
-                                    <form:input path="schedulePhases[${x.index}].phaseEndDateFormatted"
-                                                cssClass="form-control"
-                                                data-type-attribute="end"
-                                                data-index-attribute="${dateTimePickerIndex + 1}"
-                                                data-select-attribute="datetimepicker"
-                                                data-form-name="phaseEndDateFormatted"
-                                                readonly="${contestScheduleBean.usedInNonEmptyContest and schedulePhase.contestPhase.ended}"
                                             />
 
                                 </td>


### PR DESCRIPTION
This PR removes the end date editing field from the Contest Management Tool Schedules Tab. End dates are now automatically set by the controller to the start date of the following phase.

The included SQL deployment script fixes wrong end dates by setting all end dates to the start dates of the following phase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/71)
<!-- Reviewable:end -->
