### PR TITLE
Bugfix: COLAB-2435 Proposal attributes of old versions not retrieved from database

### DIFF
--- a/microservices/services/contest-service/src/main/java/org/xcolab/service/proposal/domain/proposalattribute/ProposalAttributeDaoImpl.java
+++ b/microservices/services/contest-service/src/main/java/org/xcolab/service/proposal/domain/proposalattribute/ProposalAttributeDaoImpl.java
@@ -84,7 +84,7 @@ public class ProposalAttributeDaoImpl implements ProposalAttributeDao {
             query.addConditions(PROPOSAL_ATTRIBUTE.ADDITIONAL_ID.eq(additionalId));
         }
         if (version != null) {
-            query.addConditions(PROPOSAL_ATTRIBUTE.VERSION.ge(version));
+            query.addConditions(PROPOSAL_ATTRIBUTE.VERSION.le(version));
         }
         return query.fetchInto(ProposalAttribute.class);
     }
@@ -100,7 +100,7 @@ public class ProposalAttributeDaoImpl implements ProposalAttributeDao {
         query.addConditions(PROPOSAL_ATTRIBUTE.NAME.like("IMPACT_%"));
 
         if (version != null) {
-            query.addConditions(PROPOSAL_ATTRIBUTE.VERSION.ge(version));
+            query.addConditions(PROPOSAL_ATTRIBUTE.VERSION.le(version));
         }
         return query.fetchInto(ProposalAttribute.class);
     }


### PR DESCRIPTION
This PR fixes the bug that old proposal attribute versions were not retrieved from the database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/72)
<!-- Reviewable:end -->
