### PR TITLE
COLAB-2386: Limit team name length to 35 chars

### DIFF
--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/PlatformTeamBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/wrappers/PlatformTeamBean.java
@@ -1,5 +1,7 @@
 package org.xcolab.view.pages.contestmanagement.wrappers;
 
+import org.hibernate.validator.constraints.Length;
+
 import org.xcolab.client.members.pojo.Member;
 import org.xcolab.client.members.pojo.PlatformTeam;
 
@@ -11,6 +13,7 @@ public class PlatformTeamBean {
     private List<Member> members;
 
     private Long teamId;
+    @Length(max = 35, message = "The team name is limited to 35 characters.")
     private String teamName;
 
     public PlatformTeamBean() { }

--- a/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/teamsTab.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/contestmanagement/manager/teamsTab.jspx
@@ -55,7 +55,7 @@
                 <form:hidden path="teamId"/>
 
                 <div class="addpropbox">
-                    <strong class="inputTitleLeft">Team name:</strong>
+                    <strong class="inputTitleLeft" maxlength="35">Team name:</strong>
                     <form:input path="name" cssClass="form-control"/>
                 </div>
 


### PR DESCRIPTION
This PR limit team name length to 35 chars in the Contest Management Systems Teams Tab.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/75)
<!-- Reviewable:end -->
