### PR TITLE
[COLAB-2441] Fix association of tracked visitors with users

### DIFF
--- a/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/domain/trackedvisitor2user/TrackedVisitor2UserDao.java
+++ b/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/domain/trackedvisitor2user/TrackedVisitor2UserDao.java
@@ -11,4 +11,6 @@ public interface TrackedVisitor2UserDao {
     Optional<TrackedVisitor2User> getByMemberId(long memberId);
 
     TrackedVisitor2User create(TrackedVisitor2User trackedVisitor2User);
+
+    boolean update(TrackedVisitor2User pojo);
 }

--- a/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/domain/trackedvisitor2user/TrackedVisitor2UserDaoImpl.java
+++ b/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/domain/trackedvisitor2user/TrackedVisitor2UserDaoImpl.java
@@ -48,17 +48,12 @@ public class TrackedVisitor2UserDaoImpl implements TrackedVisitor2UserDao {
 
     @Override
     public TrackedVisitor2User create(TrackedVisitor2User trackedVisitor2User) {
-        final Record record = dslContext
-                .insertInto(TRACKED_VISITOR_2_USER)
+        dslContext.insertInto(TRACKED_VISITOR_2_USER)
                 .set(TRACKED_VISITOR_2_USER.UUID_, trackedVisitor2User.getUuid_())
+                .set(TRACKED_VISITOR_2_USER.USER_ID, trackedVisitor2User.getUserId())
                 .set(TRACKED_VISITOR_2_USER.CREATE_DATE, DSL.currentTimestamp())
-                .returning(TRACKED_VISITOR_2_USER.ID_)
-                .fetchOne();
+                .execute();
 
-        if (record == null) {
-            throw new IllegalStateException("Could not retrieve inserted id for " + trackedVisitor2User);
-        }
-        trackedVisitor2User.setId_(record.getValue(TRACKED_VISITOR_2_USER.ID_));
         return trackedVisitor2User;
     }
 }

--- a/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/domain/trackedvisitor2user/TrackedVisitor2UserDaoImpl.java
+++ b/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/domain/trackedvisitor2user/TrackedVisitor2UserDaoImpl.java
@@ -56,4 +56,12 @@ public class TrackedVisitor2UserDaoImpl implements TrackedVisitor2UserDao {
 
         return trackedVisitor2User;
     }
+
+    @Override
+    public boolean update(TrackedVisitor2User pojo) {
+        return dslContext.update(TRACKED_VISITOR_2_USER)
+                .set(TRACKED_VISITOR_2_USER.USER_ID, pojo.getUserId())
+                .where(TRACKED_VISITOR_2_USER.UUID_.eq(pojo.getUuid_()))
+                .execute() > 0;
+    }
 }

--- a/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/service/TrackedVisitService.java
+++ b/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/service/TrackedVisitService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.xcolab.model.tables.pojos.TrackedVisit;
 import org.xcolab.model.tables.pojos.TrackedVisitor2User;
 import org.xcolab.service.tracking.domain.trackedvisit.TrackedVisitDao;
+import org.xcolab.service.tracking.domain.trackedvisitor2user.TrackedVisitor2UserDao;
 import org.xcolab.service.tracking.service.iptranslation.IpTranslationService;
 import org.xcolab.service.tracking.service.iptranslation.IpTranslationService.IpFormatException;
 
@@ -20,14 +21,16 @@ public class TrackedVisitService {
     private final TrackedVisitDao trackedVisitDao;
     private final IpTranslationService ipTranslationService;
     private final TrackedVisitor2UserService trackedVisitor2UserService;
+    private final TrackedVisitor2UserDao trackedVisitor2UserDao;
 
     @Autowired
     public TrackedVisitService(IpTranslationService ipTranslationService,
-            TrackedVisitDao trackedVisitDao, TrackedVisitor2UserService
-            trackedVisitor2UserService) {
+            TrackedVisitDao trackedVisitDao, TrackedVisitor2UserService trackedVisitor2UserService,
+            TrackedVisitor2UserDao trackedVisitor2UserDao) {
         this.ipTranslationService = ipTranslationService;
         this.trackedVisitDao = trackedVisitDao;
         this.trackedVisitor2UserService = trackedVisitor2UserService;
+        this.trackedVisitor2UserDao = trackedVisitor2UserDao;
     }
 
     public TrackedVisit createTrackedVisit(TrackedVisit trackedVisit, Long userId) {
@@ -43,14 +46,20 @@ public class TrackedVisitService {
             }
         }
 
-        if (StringUtils.isBlank(trackedVisit.getUuid_())) {
-            final TrackedVisitor2User trackedVisitor;
-            if (userId != null) {
-                trackedVisitor = trackedVisitor2UserService.getOrCreate(userId);
-            } else {
-                trackedVisitor = trackedVisitor2UserService.create();
-            }
+        TrackedVisitor2User trackedVisitor = null;
+        if (StringUtils.isNotBlank(trackedVisit.getUuid_())) {
+            trackedVisitor = trackedVisitor2UserDao.getByUUID(trackedVisit.getUuid_())
+                    .orElse(null);
+        }
+
+        if (trackedVisitor == null) {
+            trackedVisitor = trackedVisitor2UserService.getOrCreate(userId);
             trackedVisit.setUuid_(trackedVisitor.getUuid_());
+        } else {
+            if (trackedVisitor.getUserId() == null && userId != null) {
+                trackedVisitor.setUserId(userId);
+                trackedVisitor2UserDao.update(trackedVisitor);
+            }
         }
         return trackedVisitDao.create(trackedVisit);
     }

--- a/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/service/TrackedVisitService.java
+++ b/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/service/TrackedVisitService.java
@@ -55,11 +55,9 @@ public class TrackedVisitService {
         if (trackedVisitor == null) {
             trackedVisitor = trackedVisitor2UserService.getOrCreate(userId);
             trackedVisit.setUuid_(trackedVisitor.getUuid_());
-        } else {
-            if (trackedVisitor.getUserId() == null && userId != null) {
-                trackedVisitor.setUserId(userId);
-                trackedVisitor2UserDao.update(trackedVisitor);
-            }
+        } else if (trackedVisitor.getUserId() == null && userId != null) {
+            trackedVisitor.setUserId(userId);
+            trackedVisitor2UserDao.update(trackedVisitor);
         }
         return trackedVisitDao.create(trackedVisit);
     }

--- a/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/service/TrackedVisitor2UserService.java
+++ b/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/service/TrackedVisitor2UserService.java
@@ -20,7 +20,10 @@ public class TrackedVisitor2UserService {
         this.trackedVisitor2UserDao = trackedVisitor2UserDao;
     }
 
-    public TrackedVisitor2User getOrCreate(long memberId) {
+    public TrackedVisitor2User getOrCreate(Long memberId) {
+        if (memberId == null) {
+            return create();
+        }
         return trackedVisitor2UserDao.getByMemberId(memberId)
                 .orElseGet(() -> {
                     TrackedVisitor2User newInstance = new TrackedVisitor2User();

--- a/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/service/TrackedVisitor2UserService.java
+++ b/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/service/TrackedVisitor2UserService.java
@@ -22,19 +22,18 @@ public class TrackedVisitor2UserService {
 
     public TrackedVisitor2User getOrCreate(Long memberId) {
         if (memberId == null) {
-            return create();
+            return createUnknownVisitor();
         }
-        return trackedVisitor2UserDao.getByMemberId(memberId)
-                .orElseGet(() -> {
-                    TrackedVisitor2User newInstance = new TrackedVisitor2User();
-                    newInstance.setUserId(memberId);
-                    newInstance.setUuid_(generateUniqueUUID());
-                    return trackedVisitor2UserDao.create(newInstance);
-                });
+        return trackedVisitor2UserDao.getByMemberId(memberId).orElse(create(memberId));
     }
 
-    public TrackedVisitor2User create() {
+    private TrackedVisitor2User createUnknownVisitor() {
+        return create(null);
+    }
+
+    private TrackedVisitor2User create(Long memberId) {
         TrackedVisitor2User trackedVisitor = new TrackedVisitor2User();
+        trackedVisitor.setUserId(memberId);
         trackedVisitor.setUuid_(generateUniqueUUID());
         return trackedVisitor2UserDao.create(trackedVisitor);
     }

--- a/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/service/TrackedVisitor2UserService.java
+++ b/microservices/services/tracking-service/src/main/java/org/xcolab/service/tracking/service/TrackedVisitor2UserService.java
@@ -33,7 +33,7 @@ public class TrackedVisitor2UserService {
     public TrackedVisitor2User create() {
         TrackedVisitor2User trackedVisitor = new TrackedVisitor2User();
         trackedVisitor.setUuid_(generateUniqueUUID());
-        return trackedVisitor;
+        return trackedVisitor2UserDao.create(trackedVisitor);
     }
 
     private String generateUniqueUUID() {

--- a/sql/deployments/deployment-2017-11-26.sql
+++ b/sql/deployments/deployment-2017-11-26.sql
@@ -1,0 +1,5 @@
+-- COLAB-2441
+ALTER TABLE xcolab_TrackedVisitor2User MODIFY uuid_ VARCHAR(36) NOT NULL;
+ALTER TABLE xcolab_TrackedVisitor2User DROP id_;
+ALTER TABLE xcolab_TrackedVisitor2User DROP PRIMARY KEY;
+ALTER TABLE xcolab_TrackedVisitor2User ADD PRIMARY KEY (uuid_);

--- a/sql/starter/xcolab-schema.sql
+++ b/sql/starter/xcolab-schema.sql
@@ -744,11 +744,9 @@ CREATE TABLE `xcolab_ConfigurationAttribute` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `xcolab_TrackedVisitor2User` (
-  `id_` bigint(20) NOT NULL AUTO_INCREMENT,
-  `uuid_` varchar(36) DEFAULT NULL,
+  `uuid_` varchar(36) NOT NULL PRIMARY KEY,
   `userId` bigint(20) DEFAULT NULL,
-  `createDate` datetime DEFAULT NULL,
-  PRIMARY KEY (`id_`)
+  `createDate` datetime DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `Users_Groups` (


### PR DESCRIPTION
This PR restores and old feature that could link tracked visitors to accounts when they log in. There were two errors here:
1. New TrackedVisitors were not being created at all
2. Existing TrackedVisitors were never updated with a userId

~Depends on #76.~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/78)
<!-- Reviewable:end -->
