### PR TITLE
[COLAB-2436] Fix redirect loop in Google sign in

### DIFF
--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/ProposalAttributeClient.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/ProposalAttributeClient.java
@@ -52,10 +52,6 @@ public final class ProposalAttributeClient {
                 .execute().toPojo(serviceNamespace);
     }
 
-    public ProposalAttribute getImpactProposalAttributes(Long proposalId) {
-        return null;
-    }
-
     public ProposalAttribute getProposalAttribute(Long proposalId, String name, Long additionalId) {
         ListQuery<ProposalAttributeDto> listQ =
                 proposalAttributeResource.list()

--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/ProposalAttributeClientUtil.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/ProposalAttributeClientUtil.java
@@ -23,11 +23,6 @@ public final class ProposalAttributeClientUtil {
         return client.createProposalAttribute(proposalAttribute);
     }
 
-    public static ProposalAttribute getImpactProposalAttributes(
-            Long proposalId) {
-        return client.getImpactProposalAttributes(proposalId);
-    }
-
     public static ProposalAttribute getProposalAttribute(
             Long proposalId, String name, Long additionalId) {
         return client.getProposalAttribute(proposalId, name, additionalId);

--- a/microservices/util/entity-utils/src/main/java/org/xcolab/entity/utils/LinkUtils.java
+++ b/microservices/util/entity-utils/src/main/java/org/xcolab/entity/utils/LinkUtils.java
@@ -36,25 +36,17 @@ public final class LinkUtils {
     /**
      * Takes an absolute URI and removes the scheme, host, and port (if present).
      *
-     * An empty, null, or already relative URI will be returned unchanged.
-     *
      * @param uri some uri - absolute or relative
      * @return a relative uri
      */
     public static String getRelativeUri(String uri) {
-        if (uri == null) {
-            return null;
+        final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(uri);
+        final UriComponents uriComponents = uriBuilder.build();
+        StringBuilder relativeUri = new StringBuilder();
+        relativeUri.append(uriComponents.getPath() != null ? uriComponents.getPath() : "/");
+        if (uriComponents.getQuery() != null) {
+            relativeUri.append("?").append(uriComponents.getQuery());
         }
-        if (uri.startsWith("http://") || uri.startsWith("https://")) {
-            final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(uri);
-            final UriComponents uriComponents = uriBuilder.build();
-            StringBuilder relativeUri = new StringBuilder();
-            relativeUri.append(uriComponents.getPath() != null ? uriComponents.getPath() : "/");
-            if (uriComponents.getQuery() != null) {
-                relativeUri.append("?").append(uriComponents.getQuery());
-            }
-            return relativeUri.toString();
-        }
-        return uri;
+        return relativeUri.toString();
     }
 }

--- a/microservices/util/entity-utils/src/main/java/org/xcolab/entity/utils/LinkUtils.java
+++ b/microservices/util/entity-utils/src/main/java/org/xcolab/entity/utils/LinkUtils.java
@@ -42,17 +42,18 @@ public final class LinkUtils {
      * @return a relative uri
      */
     public static String getRelativeUri(String uri) {
-        if (StringUtils.isNotEmpty(uri)) {
-            if (uri.startsWith("http://") || uri.startsWith("https://")) {
-                final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(uri);
-                final UriComponents uriComponents = uriBuilder.build();
-                StringBuilder relativeUri = new StringBuilder();
-                relativeUri.append(uriComponents.getPath() != null ? uriComponents.getPath() : "/");
-                if (uriComponents.getQuery() != null) {
-                    relativeUri.append("?").append(uriComponents.getQuery());
-                }
-                return relativeUri.toString();
+        if (uri == null) {
+            return null;
+        }
+        if (uri.startsWith("http://") || uri.startsWith("https://")) {
+            final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(uri);
+            final UriComponents uriComponents = uriBuilder.build();
+            StringBuilder relativeUri = new StringBuilder();
+            relativeUri.append(uriComponents.getPath() != null ? uriComponents.getPath() : "/");
+            if (uriComponents.getQuery() != null) {
+                relativeUri.append("?").append(uriComponents.getQuery());
             }
+            return relativeUri.toString();
         }
         return uri;
     }

--- a/microservices/util/entity-utils/src/main/java/org/xcolab/entity/utils/LinkUtils.java
+++ b/microservices/util/entity-utils/src/main/java/org/xcolab/entity/utils/LinkUtils.java
@@ -1,6 +1,8 @@
 package org.xcolab.entity.utils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import org.xcolab.client.admin.attributes.platform.PlatformAttributeKey;
 
@@ -29,5 +31,29 @@ public final class LinkUtils {
 
     public static String getAbsoluteUrl(String relativeUri) {
         return PlatformAttributeKey.COLAB_URL.get() + relativeUri;
+    }
+
+    /**
+     * Takes an absolute URI and removes the scheme, host, and port (if present).
+     *
+     * An empty, null, or already relative URI will be returned unchanged.
+     *
+     * @param uri some uri - absolute or relative
+     * @return a relative uri
+     */
+    public static String getRelativeUri(String uri) {
+        if (StringUtils.isNotEmpty(uri)) {
+            if (uri.startsWith("http://") || uri.startsWith("https://")) {
+                final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(uri);
+                final UriComponents uriComponents = uriBuilder.build();
+                StringBuilder relativeUri = new StringBuilder();
+                relativeUri.append(uriComponents.getPath() != null ? uriComponents.getPath() : "/");
+                if (uriComponents.getQuery() != null) {
+                    relativeUri.append("?").append(uriComponents.getQuery());
+                }
+                return relativeUri.toString();
+            }
+        }
+        return uri;
     }
 }

--- a/view/src/main/java/org/xcolab/view/pages/loginregister/LoginRegisterController.java
+++ b/view/src/main/java/org/xcolab/view/pages/loginregister/LoginRegisterController.java
@@ -72,10 +72,7 @@ public class LoginRegisterController {
 //    public void initBinder(WebDataBinder binder) {
 //        binder.setValidator(validator);
 //    }
-
-    /**
-     * Main view displayed for contact form
-     */
+    
     @GetMapping("/register")
     public String register(HttpServletRequest request, HttpServletResponse response, Model model) {
 

--- a/view/src/main/java/org/xcolab/view/pages/loginregister/LoginRegisterService.java
+++ b/view/src/main/java/org/xcolab/view/pages/loginregister/LoginRegisterService.java
@@ -240,7 +240,7 @@ public class LoginRegisterService {
         try {
             Authentication authentication =
                     authenticationService.authenticate(request, response, member);
-            authenticationSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+            authenticationSuccessHandler.onAuthenticationSuccess(request, response, authentication, false);
         } catch (IOException e) {
             authenticationService.logout(request, response);
             throw new InternalException(e);

--- a/view/src/main/java/org/xcolab/view/pages/loginregister/LoginRegisterService.java
+++ b/view/src/main/java/org/xcolab/view/pages/loginregister/LoginRegisterService.java
@@ -240,7 +240,9 @@ public class LoginRegisterService {
         try {
             Authentication authentication =
                     authenticationService.authenticate(request, response, member);
-            authenticationSuccessHandler.onAuthenticationSuccess(request, response, authentication, false);
+            final boolean redirectOnSuccess = false;
+            authenticationSuccessHandler.onAuthenticationSuccess(request, response, authentication,
+                    redirectOnSuccess);
         } catch (IOException e) {
             authenticationService.logout(request, response);
             throw new InternalException(e);

--- a/view/src/main/java/org/xcolab/view/pages/loginregister/singlesignon/FacebookController.java
+++ b/view/src/main/java/org/xcolab/view/pages/loginregister/singlesignon/FacebookController.java
@@ -144,6 +144,7 @@ public class FacebookController {
                 }*/
 
                 loginRegisterService.logIn(request, response, member);
+                response.sendRedirect(redirectUrl);
                 return;
             } catch (MemberNotFoundException ignored) {
             }
@@ -166,6 +167,7 @@ public class FacebookController {
                 updateUserAccountInformation(member, jsonObject);
 
                 loginRegisterService.logIn(request, response, member);
+                response.sendRedirect(redirectUrl);
                 return;
             } catch (MemberNotFoundException ignored) {
             }

--- a/view/src/main/java/org/xcolab/view/pages/loginregister/singlesignon/FacebookController.java
+++ b/view/src/main/java/org/xcolab/view/pages/loginregister/singlesignon/FacebookController.java
@@ -16,6 +16,7 @@ import org.xcolab.client.admin.attributes.configuration.ConfigurationAttributeKe
 import org.xcolab.client.members.MembersClient;
 import org.xcolab.client.members.exceptions.MemberNotFoundException;
 import org.xcolab.client.members.pojo.Member;
+import org.xcolab.entity.utils.LinkUtils;
 import org.xcolab.view.auth.AuthenticationService;
 import org.xcolab.view.auth.handlers.AuthenticationSuccessHandler;
 import org.xcolab.view.auth.login.AuthenticationError;
@@ -96,7 +97,8 @@ public class FacebookController {
 
         String redirectUrl = (String) session
                 .getAttribute(LoginRegisterController.PRE_LOGIN_REFERRER_KEY);
-        if ((redirectUrl) == null || (redirectUrl.isEmpty())) {
+        redirectUrl = LinkUtils.getRelativeUri(redirectUrl);
+        if (StringUtils.isEmpty(redirectUrl)) {
             redirectUrl = "/";
         }
 

--- a/view/src/main/java/org/xcolab/view/pages/loginregister/singlesignon/GoogleController.java
+++ b/view/src/main/java/org/xcolab/view/pages/loginregister/singlesignon/GoogleController.java
@@ -18,6 +18,7 @@ import org.xcolab.client.members.exceptions.MemberNotFoundException;
 import org.xcolab.client.members.pojo.Member;
 import org.xcolab.client.sharedcolab.SharedColabClient;
 import org.xcolab.client.sharedcolab.pojo.SharedMember;
+import org.xcolab.entity.utils.LinkUtils;
 import org.xcolab.view.pages.loginregister.CreateUserBean;
 import org.xcolab.view.pages.loginregister.ImageUploadUtils;
 import org.xcolab.view.pages.loginregister.LoginRegisterController;
@@ -90,7 +91,8 @@ public class GoogleController {
         session.removeAttribute(SSOKeys.FACEBOOK_USER_ID);
 
         String redirectUrl = (String) session.getAttribute(LoginRegisterController.PRE_LOGIN_REFERRER_KEY);
-        if (StringUtils.isBlank(redirectUrl)) {
+        redirectUrl = LinkUtils.getRelativeUri(redirectUrl);
+        if (StringUtils.isEmpty(redirectUrl)) {
             redirectUrl = "/";
         }
         session.removeAttribute(LoginRegisterController.PRE_LOGIN_REFERRER_KEY);

--- a/view/src/test/java/org/xcolab/entity/utils/LinkUtilsTest.java
+++ b/view/src/test/java/org/xcolab/entity/utils/LinkUtilsTest.java
@@ -1,0 +1,46 @@
+package org.xcolab.entity.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LinkUtilsTest {
+
+    private static final String BASE_URL = "https://climatecolab.org";
+
+    @Test
+    public void testGetRelativeUri() throws Exception {
+        final String result = LinkUtils.getRelativeUri(BASE_URL + "/contests");
+        assertEquals("Relative URI not correct", "/contests", result);
+    }
+
+    @Test
+    public void testGetRelativeUri__queryParam() throws Exception {
+        final String result = LinkUtils.getRelativeUri(BASE_URL + "/contests?test=1&test2=2");
+        assertEquals("Query params not handled correctly", "/contests?test=1&test2=2", result);
+    }
+
+    @Test
+    public void testGetRelativeUri__emptyPath__shouldReturnRoot() throws Exception {
+        final String result = LinkUtils.getRelativeUri(BASE_URL);
+        assertEquals("Empty path not handled correctly", "/", result);
+    }
+
+    @Test
+    public void testGetRelativeUri__relativeUri__shouldReturnItself() throws Exception {
+        final String result = LinkUtils.getRelativeUri("/contests");
+        assertEquals("Relative uri not returned unchanged", "/contests", result);
+    }
+
+    @Test
+    public void testGetRelativeUri__empty__shouldReturnEmpty() throws Exception {
+        final String result = LinkUtils.getRelativeUri("");
+        assertEquals("Empty uri handled incorrectly", "", result);
+    }
+
+    @Test
+    public void testGetRelativeUri__null__shouldReturnNull() throws Exception {
+        final String result = LinkUtils.getRelativeUri(null);
+        assertEquals("Null uri handled incorrectly", null, result);
+    }
+}

--- a/view/src/test/java/org/xcolab/entity/utils/LinkUtilsTest.java
+++ b/view/src/test/java/org/xcolab/entity/utils/LinkUtilsTest.java
@@ -33,14 +33,19 @@ public class LinkUtilsTest {
     }
 
     @Test
-    public void testGetRelativeUri__empty__shouldReturnEmpty() throws Exception {
+    public void testGetRelativeUri__empty__shouldReturnRoot() throws Exception {
         final String result = LinkUtils.getRelativeUri("");
-        assertEquals("Empty uri handled incorrectly", "", result);
+        assertEquals("Empty uri handled incorrectly", "/", result);
     }
 
     @Test
-    public void testGetRelativeUri__null__shouldReturnNull() throws Exception {
-        final String result = LinkUtils.getRelativeUri(null);
-        assertEquals("Null uri handled incorrectly", null, result);
+    public void testGetRelativeUri__blank__shouldReturnRoot() throws Exception {
+        final String result = LinkUtils.getRelativeUri(" ");
+        assertEquals("Blank uri handled incorrectly", "/", result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetRelativeUri__null__shouldFail() throws Exception {
+        LinkUtils.getRelativeUri(null);
     }
 }


### PR DESCRIPTION
This PR fixes a redirect loop when google displays the account chooser (i.e. when you're signed into more than one Google account). This was caused by the AuthenticationSuccessHandler always redirecting to the referrer.

This PR also makes sure the redirect URL is always a relative url, as absolute urls don't make sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/79)
<!-- Reviewable:end -->
