### PR TITLE
COLAB-2407: Fix proposal version picker

### DIFF
--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/pojo/Proposal.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/pojo/Proposal.java
@@ -141,8 +141,8 @@ public class Proposal extends AbstractProposal {
         this(proposal, proposal.getCurrentVersion(), null, contestPhase, proposal2Phase);
     }
 
-    public Proposal(Proposal proposal, Contest contest) {
-        this(proposal, null, contest, null, null);
+    public Proposal(Proposal proposal, Integer version, Contest contest) {
+        this(proposal, version, contest, null, null);
     }
 
     public Proposal(Proposal proposal, Integer version, Contest contest,

--- a/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextHelper.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/utils/context/ProposalContextHelper.java
@@ -165,7 +165,8 @@ public class ProposalContextHelper {
         Proposal proposal = null;
         if (givenProposalId > 0) {
             try {
-                proposal = new Proposal(proposalClient.getProposal(givenProposalId), contest);
+                Integer version = givenVersion > 0 ? givenVersion : null;
+                proposal = new Proposal(proposalClient.getProposal(givenProposalId), version, contest);
             } catch (ProposalNotFoundException e) {
                 log.debug("Invalid proposal supplied: givenProposalId = {}", givenProposalId);
                 throw new InvalidAccessException();


### PR DESCRIPTION
This PR fixes the bug that clicking the version picker has no effect. Now, clicking a version in the picker results in that proposal version being displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/80)
<!-- Reviewable:end -->
