### PR TITLE
[COLAB-2393] Edit Profile Save Button Redirects to Profile View

### DIFF
--- a/view/src/main/java/org/xcolab/view/pages/profile/view/UserProfileController.java
+++ b/view/src/main/java/org/xcolab/view/pages/profile/view/UserProfileController.java
@@ -315,7 +315,7 @@ public class UserProfileController {
                 sendUpdatedEmail(currentUserProfile.getUser());
             }
             AlertMessage.CHANGES_SAVED.flash(request);
-            return EDIT_PROFILE_VIEW;
+            return SHOW_PROFILE_VIEW;
         } else {
             return "redirect:/members/profile/" + memberId;
         }


### PR DESCRIPTION
This PR changes the behavior of the save button in the edit profile view. If the edit was successful, the user is redirected to the profile view instead of the edit profile view.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/82)
<!-- Reviewable:end -->
