### PR TITLE
[COLAB-2438] Discard Button closes Proposal Edit View

### DIFF
--- a/view/src/main/webapp/WEB-INF/jsp/proposals/proposalDetails_edit.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/proposals/proposalDetails_edit.jspx
@@ -299,7 +299,7 @@
                 <c:choose>
                     <c:when test="${proposal.currentVersion > 0 }">
                         <xcolab:proposalLink proposal="${proposal}" cssClass="c-Button__secondary"
-                                             linkId="discardChangesButton" text="DISCARD changes" />
+                                             linkId="discardChangesButton" text="DISCARD changes" edit="false" />
                     </c:when>
                     <c:otherwise>
                         <!--  proposal creation, return to contest proposals page on discard -->


### PR DESCRIPTION
This PR fixes the Discard button on the proposal edit view. Previously, this button would result in a reload of the edit view page. Now, the user is redirected to the proposal details view.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/84)
<!-- Reviewable:end -->
