### PR TITLE
[COLAB-2325] Fix member list name sort order

### DIFF
--- a/microservices/clients/members-client/src/main/java/org/xcolab/client/members/MembersClient.java
+++ b/microservices/clients/members-client/src/main/java/org/xcolab/client/members/MembersClient.java
@@ -1,5 +1,6 @@
 package org.xcolab.client.members;
 
+import org.xcolab.client.admin.attributes.configuration.ConfigurationAttributeKey;
 import org.xcolab.client.members.exceptions.LockoutLoginException;
 import org.xcolab.client.members.exceptions.MemberCategoryNotFoundException;
 import org.xcolab.client.members.exceptions.MemberNotFoundException;
@@ -85,7 +86,11 @@ public final class MembersClient {
 
             switch (sortField) {
                 case "USER_NAME":
-                    memberListQuery.queryParam("sort", prefix + "screenName");
+                    String sortType = "screenName";
+                    if (ConfigurationAttributeKey.DISPLAY_FIRST_NAME_LAST_NAME.get()) {
+                        sortType = "displayName";
+                    }
+                    memberListQuery.queryParam("sort", prefix + sortType);
                     break;
                 case "MEMBER_SINCE":
                     memberListQuery.queryParam("sort", prefix + "createDate");


### PR DESCRIPTION
This PR fixes the member list name sort order. If the configuration attribute key `DISPLAY_FIRST_NAME_LAST_NAME` is set to `true`, the name-sorted member list is sorted by display name instead of `screenName`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/85)
<!-- Reviewable:end -->
