### PR TITLE
[COLAB-2519] Fix retrieval of ribbon year

### DIFF
--- a/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/pojo/phases/ProposalContestPhaseAttribute.java
+++ b/microservices/clients/contestproposal-client/src/main/java/org/xcolab/client/proposals/pojo/phases/ProposalContestPhaseAttribute.java
@@ -1,33 +1,36 @@
 package org.xcolab.client.proposals.pojo.phases;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import org.xcolab.client.contest.ContestClient;
 import org.xcolab.util.http.client.enums.ServiceNamespace;
+
+import java.util.Date;
 
 public class ProposalContestPhaseAttribute  extends AbstractProposalContestPhaseAttribute{
 
-    public ProposalContestPhaseAttribute() {}
+    private final ServiceNamespace serviceNamespace;
+
+    public ProposalContestPhaseAttribute() {
+        serviceNamespace = ServiceNamespace.instance();
+    }
 
     public ProposalContestPhaseAttribute(ProposalContestPhaseAttribute value) {
         super(value);
-    }
-
-    public ProposalContestPhaseAttribute(
-            Long id_,
-            Long proposalid,
-            Long contestphaseid,
-            String name,
-            Long additionalid,
-            Long numericvalue,
-            String stringvalue,
-            Double realvalue
-    ) {
-        super(id_, proposalid, contestphaseid, name, additionalid,
-                numericvalue, stringvalue, realvalue);
+        serviceNamespace = ServiceNamespace.instance();
     }
 
     public ProposalContestPhaseAttribute(
             AbstractProposalContestPhaseAttribute abstractProposalContestPhaseAttribute,
             ServiceNamespace serviceNamespace) {
         super(abstractProposalContestPhaseAttribute);
+        this.serviceNamespace = serviceNamespace;
+    }
+
+    @JsonIgnore
+    public Date getStartDate() {
+        return ContestClient.fromNamespace(serviceNamespace)
+                .getContestPhase(getContestPhaseId()).getPhaseStartDateDt();
     }
 }

--- a/view/src/main/java/org/xcolab/view/pages/profile/beans/BadgeBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/profile/beans/BadgeBean.java
@@ -22,27 +22,31 @@ public class BadgeBean implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final List<Badge> badges = new ArrayList<>();
+    private List<Badge> badges;
 
     public BadgeBean(long userId) {
-        populateBadges(userId);
+        badges = getBadges(userId);
     }
 
-    private void populateBadges(long userId) {
+    private List<Badge> getBadges(long userId) {
+        final List<Badge> badges = new ArrayList<>();
         for (Proposal proposal : ProposalClientUtil.getMemberProposals(userId)) {
-            getRibbonAttribute(proposal)
-                    .ifPresent(ribbonAttribute -> {
-                        final ContestPhaseRibbonType ribbonType = ContestClientUtil
-                                .getContestPhaseRibbonType(ribbonAttribute.getNumericValue());
+            final Optional<ProposalContestPhaseAttribute> ribbonAttributeOpt =
+                    getRibbonAttribute(proposal);
+            if (ribbonAttributeOpt.isPresent()) {
+                final ProposalContestPhaseAttribute ribbonAttribute = ribbonAttributeOpt.get();
+                final ContestPhaseRibbonType ribbonType = ContestClientUtil
+                        .getContestPhaseRibbonType(ribbonAttribute.getNumericValue());
 
-                        if (ribbonType.getRibbon() > 0) {
-                            final ContestPhase phase = ContestClientUtil.getContestPhase(
-                                    ribbonAttribute.getContestPhaseId());
-                            badges.add(new Badge(ribbonType, proposal, proposal.getName(),
-                                    phase.getContest()));
-                        }
-                    });
+                if (ribbonType.getRibbon() > 0) {
+                    final ContestPhase phase = ContestClientUtil.getContestPhase(
+                            ribbonAttribute.getContestPhaseId());
+                    badges.add(new Badge(ribbonType, proposal, proposal.getName(),
+                            phase.getContest()));
+                }
+            }
         }
+        return badges;
     }
 
     private Optional<ProposalContestPhaseAttribute> getRibbonAttribute(Proposal proposal) {

--- a/view/src/main/java/org/xcolab/view/pages/profile/beans/BadgeBean.java
+++ b/view/src/main/java/org/xcolab/view/pages/profile/beans/BadgeBean.java
@@ -1,17 +1,10 @@
 package org.xcolab.view.pages.profile.beans;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.xcolab.client.contest.ContestClientUtil;
-import org.xcolab.client.contest.exceptions.ContestNotFoundException;
-import org.xcolab.client.contest.pojo.Contest;
 import org.xcolab.client.contest.pojo.phases.ContestPhase;
 import org.xcolab.client.contest.pojo.phases.ContestPhaseRibbonType;
-import org.xcolab.client.proposals.ProposalAttributeClientUtil;
 import org.xcolab.client.proposals.ProposalClientUtil;
 import org.xcolab.client.proposals.ProposalPhaseClientUtil;
-import org.xcolab.client.proposals.enums.ProposalAttributeKeys;
 import org.xcolab.client.proposals.pojo.Proposal;
 import org.xcolab.client.proposals.pojo.phases.ProposalContestPhaseAttribute;
 import org.xcolab.util.enums.contest.ProposalContestPhaseAttributeKeys;
@@ -19,64 +12,58 @@ import org.xcolab.view.pages.profile.entity.Badge;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Date;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 
 public class BadgeBean implements Serializable {
 
     private static final long serialVersionUID = 1L;
-    private final static Logger _log = LoggerFactory.getLogger(BadgeBean.class);
-    private final long userId;
-    private final List<Badge> badges;
+
+    private final List<Badge> badges = new ArrayList<>();
 
     public BadgeBean(long userId) {
-        this.userId = userId;
-        badges = new ArrayList<>();
-        fetchBadges();
+        populateBadges(userId);
     }
 
-    private void fetchBadges() {
-        for(Proposal p : ProposalClientUtil.getMemberProposals(userId)) {
-            try {
-                final ContestPhaseRibbonType ribbonType = getRibbonType(p);
+    private void populateBadges(long userId) {
+        for (Proposal proposal : ProposalClientUtil.getMemberProposals(userId)) {
+            getRibbonAttribute(proposal)
+                    .ifPresent(ribbonAttribute -> {
+                        final ContestPhaseRibbonType ribbonType = ContestClientUtil
+                                .getContestPhaseRibbonType(ribbonAttribute.getNumericValue());
 
-                if (ribbonType != null  && ribbonType.getRibbon() > 0) {
-                    Contest contest = ProposalClientUtil.getCurrentContestForProposal(p.getProposalId());
-                    String proposalTitle = ProposalAttributeClientUtil
-                            .getProposalAttribute(p.getProposalId(), ProposalAttributeKeys.NAME, 0L)
-                            .getStringValue();
-                    badges.add(new Badge(ribbonType, p, proposalTitle, contest));
-                }
-            } catch (ContestNotFoundException e) {
-                _log.warn("Could not add badge to user profile view for userId: {} and proposalId: {}",
-                        p.getProposalId(), e);
-            }
+                        if (ribbonType.getRibbon() > 0) {
+                            final ContestPhase phase = ContestClientUtil.getContestPhase(
+                                    ribbonAttribute.getContestPhaseId());
+                            badges.add(new Badge(ribbonType, proposal, proposal.getName(),
+                                    phase.getContest()));
+                        }
+                    });
         }
     }
 
-    private ContestPhaseRibbonType getRibbonType(Proposal p) {
-        ContestPhaseRibbonType contestPhaseRibbonType = null;
-        List<Long> phasesForProposal = ProposalPhaseClientUtil.getContestPhasesForProposal(p.getProposalId());
+    private Optional<ProposalContestPhaseAttribute> getRibbonAttribute(Proposal proposal) {
+        List<Long> phasesForProposal = ProposalPhaseClientUtil.getContestPhasesForProposal(
+                proposal.getProposalId());
+        return phasesForProposal.stream()
+                .map(getRibbonAttributeFunction(proposal.getProposalId()))
+                .filter(Objects::nonNull)
+                .max(getStartDateComparator());
+    }
 
-        Date phaseStartDate = p.getCreateDate();
-        for (Long phaseId : phasesForProposal) {
-            final ProposalContestPhaseAttribute ribbonAttribute =
-                    ProposalPhaseClientUtil.getProposalContestPhaseAttribute(p.getProposalId(),
-                            phaseId, ProposalContestPhaseAttributeKeys.RIBBON);
-            if (ribbonAttribute != null) {
-                long typeId = ribbonAttribute.getNumericValue();
+    private Comparator<ProposalContestPhaseAttribute> getStartDateComparator() {
+        return Comparator.comparing(attribute -> ContestClientUtil
+                .getContestPhase(attribute.getContestPhaseId()).getPhaseStartDateDt());
+    }
 
-                ContestPhase contestPhase = ContestClientUtil.getContestPhase(phaseId);
-
-                //if there are several phases with ribbons, the latest takes precedence
-                if (!phaseStartDate.after(contestPhase.getPhaseStartDateDt())) {
-                    contestPhaseRibbonType = ContestClientUtil.getContestPhaseRibbonType(typeId);
-                    phaseStartDate = contestPhase.getPhaseStartDateDt();
-                }
-            }
-        }
-
-        return contestPhaseRibbonType;
+    private Function<Long, ProposalContestPhaseAttribute> getRibbonAttributeFunction(
+            Long proposalId) {
+        return phaseId -> ProposalPhaseClientUtil
+                .getProposalContestPhaseAttribute(proposalId, phaseId,
+                        ProposalContestPhaseAttributeKeys.RIBBON);
     }
 
     public List<Badge> getBadges() {


### PR DESCRIPTION
This PR fixes how the year of a ribbon is retrieved. This used to be based on the latest contest a proposal is in, which is a problem when the proposal has been moved out of the contest in which it received a ribbon.

The main difference is that instead of calling `ProposalClientUtil.getCurrentContestForProposal(long)`, we now get the phase from the `ProposalContestPhaseAttribute` and then call `phase.getContest()`. Since we need the attribute for that, this PR also extracts the attribute retrieval into a separate function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/95)
<!-- Reviewable:end -->
