### PR TITLE
[COLAB-2268] Add default image size to Contest widget

### DIFF
--- a/view/src/main/resources/static/sass/partials/components/_c-ContestBox.scss
+++ b/view/src/main/resources/static/sass/partials/components/_c-ContestBox.scss
@@ -57,6 +57,9 @@ $c-ContestBox--hover__boxShadow: 0 0 10px #666 !default;
 .c-ContestBox__image { //.contestbox .img-wrap {
   float: left;
   margin-right: 18px;
+  img {
+    display: block;
+  }
 }
 
 .c-ContestBox__text--compact {

--- a/view/src/main/webapp/WEB-INF/jsp/widgets/contests/showContests.jspx
+++ b/view/src/main/webapp/WEB-INF/jsp/widgets/contests/showContests.jspx
@@ -15,7 +15,7 @@
             <div class="c-ContestBox backgroundLight">
                 <div class="c-ContestBox__image">
                     <a href="${contest.contestUrl}">
-                        <img src="${contest.logoPath}" width="151" height="151" alt="${contest.contestShortName}" />
+                        <img src="${contest.logoPath}" width="150" height="150" alt="${contest.contestShortName}" />
                     </a>
                 </div>
                 <div class="c-ContestBox__text">


### PR DESCRIPTION
Fixed the issue in the contest widget. I did not find the same issue in other parts of the application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/99)
<!-- Reviewable:end -->
