### PR TITLE
[COLAB-2458] Bugfix: Wrong Proposal Editor Character Coung

### DIFF
--- a/view/src/main/resources/static/js/configureCkEditor.js
+++ b/view/src/main/resources/static/js/configureCkEditor.js
@@ -18,13 +18,11 @@ function markEditorDirty(editor) {
 function countCharacters(input, editor) {
     if (editor) {
         if (editor == null || editor.document == null) return 0;
-        if (editor.document['$'].body.textContent) {
-            return jQuery.trim(editor.document['$'].body.textContent).length;
-
-        }
-        if (editor.document['$'].body.innerText) {
-            return jQuery.trim(editor.document['$'].body.innerText).length;
-        }
+        var text = (editor.document['$'].body.textContent || editor.document['$'].body.innerText);
+        // remove zero width spaces
+        text = text.replace(/\u200b/g, '');
+        text = jQuery.trim(text);
+        return text.length;
     }
     var numberOfLines = input.val().split(/\r\n|\r|\n/).length - 1 ;//java will count \n as \r\n
     input.val().replace(/&lt;[^&gt;]*&gt;/g, "").replace(/\s+/g, " ").length


### PR DESCRIPTION
This PR fixes a bug where the char counter in the proposal editor is too high.

The reason for this bug is that CKEditor inserts zero width spaces (ZWS) (\u200b) into the text, which survive the jQuery.trim and therefore are being counted as well. With this PR, the ZWS are not being counted against the char limit anymore.

See [here](https://bugs.webkit.org/show_bug.cgi?id=15256) for more info about the ZWS insertion in CKEditor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/102)
<!-- Reviewable:end -->
