### PR TITLE
[COLAB-2557] Fix counting endpoint for messages

### DIFF
--- a/microservices/services/members-service/src/main/java/org/xcolab/service/members/domain/messaging/MessageDaoImpl.java
+++ b/microservices/services/members-service/src/main/java/org/xcolab/service/members/domain/messaging/MessageDaoImpl.java
@@ -46,8 +46,12 @@ public class MessageDaoImpl implements MessageDao {
     public int countByGiven(Long senderId, Long recipientId, Boolean isArchived, Boolean isOpened, Timestamp sinceDate) {
         final SelectQuery<Record1<Integer>> query = dslContext.selectCount()
                 .from(MESSAGE)
-                .join(MESSAGE_RECIPIENT_STATUS).on(MESSAGE.MESSAGE_ID.eq(MESSAGE_RECIPIENT_STATUS.MESSAGE_ID))
                 .getQuery();
+
+        if (recipientId != null || isArchived != null || isOpened != null) {
+            query.addJoin(MESSAGE_RECIPIENT_STATUS,
+                    MESSAGE.MESSAGE_ID.eq(MESSAGE_RECIPIENT_STATUS.MESSAGE_ID));
+        }
 
         if (senderId != null) {
             query.addConditions(MESSAGE.FROM_ID.eq(senderId));


### PR DESCRIPTION
This PR fixes the message counting endpoint - it used to add a join to the recipients table even when not adding conditions on that table, which lead to an over count for messages with more than one recipient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/109)
<!-- Reviewable:end -->
