### PR TITLE
[COLAB-2570] Improved proposal export

### DIFF
--- a/view/src/main/java/org/xcolab/view/pages/contestmanagement/utils/ProposalCsvWriter.java
+++ b/view/src/main/java/org/xcolab/view/pages/contestmanagement/utils/ProposalCsvWriter.java
@@ -2,26 +2,36 @@ package org.xcolab.view.pages.contestmanagement.utils;
 
 import org.xcolab.client.admin.attributes.platform.PlatformAttributeKey;
 import org.xcolab.client.contest.pojo.Contest;
+import org.xcolab.client.contest.pojo.templates.PlanSectionDefinition;
 import org.xcolab.client.proposals.ProposalClientUtil;
 import org.xcolab.client.proposals.pojo.Proposal;
+import org.xcolab.client.proposals.pojo.ProposalTeamMember;
 import org.xcolab.view.util.CsvResponseWriter;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 
 public class ProposalCsvWriter extends CsvResponseWriter {
 
     private static final List<String> COLUMN_NAMES = Arrays.asList(
-            "Proposal id",
             "Contest id",
+            "Contest name",
+            "Proposal id",
             "Proposal link",
             "Proposal name",
-            "Contest name"
-            );
+            "Proposal team name",
+            "Proposal team size",
+            "Proposal team members",
+            "Proposal authorId",
+            "Proposal create date",
+            "Proposal update date",
+            "Proposal pitch"
+    );
 
     public ProposalCsvWriter(HttpServletResponse response) throws IOException {
         super("proposalReport", COLUMN_NAMES, response);
@@ -34,14 +44,30 @@ public class ProposalCsvWriter extends CsvResponseWriter {
 
         for (Proposal proposal : proposals) {
             List<String> row = new ArrayList<>();
-            addValue(row, proposal.getProposalId());
             addValue(row, contest.getContestPK());
+            addValue(row, contest.getContestShortName());
+
+            addValue(row, proposal.getProposalId());
             final String proposalUrl = colabUrl + proposal.getProposalLinkUrl(contest);
             addValue(row, proposalUrl);
             addValue(row, proposal.getName());
-            addValue(row, contest.getContestShortName());
+            addValue(row, proposal.getTeam());
+            addValue(row, proposal.getMembers().size());
+            addValue(row, proposal.getMembers().stream()
+                    .map(ProposalTeamMember::getUserId)
+                    .map(String::valueOf)
+                    .collect(Collectors.joining(",")));
+            addValue(row, proposal.getAuthorId());
+            addValue(row, proposal.getCreateDate());
+            addValue(row, proposal.getUpdatedDate());
+            addValue(row, proposal.getPitch());
 
-            writeRow(row);
+            List<String> sectionContent = new ArrayList<>();
+            for (PlanSectionDefinition section:  proposal.getSections()) {
+                addValue(sectionContent, "<h1>" + section.getTitle() + "</h1>" + section.getContent());
+            }
+
+            writeRow(row, sectionContent);
         }
     }
 

--- a/view/src/main/java/org/xcolab/view/util/CsvResponseWriter.java
+++ b/view/src/main/java/org/xcolab/view/util/CsvResponseWriter.java
@@ -1,6 +1,7 @@
 package org.xcolab.view.util;
 
 import au.com.bytecode.opencsv.CSVWriter;
+import org.apache.commons.collections4.ListUtils;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.Assert;
@@ -64,9 +65,38 @@ public abstract class CsvResponseWriter implements Closeable {
         }
     }
 
+    /**
+     * Writes a row of values to the list.
+     *
+     * The row must have exactly as many columns as defined in the constructor of this class
+     * or an exception will be thrown.
+     *
+     * @param cols A list of columns for this row.
+     *
+     * @throws IllegalArgumentException if {@code cols.size() != numColumns}
+     * @throws NullPointerException if cols is null
+     */
     protected void writeRow(List<String> cols) {
+        writeRow(cols, null);
+    }
+
+    /**
+     * Writes a new row with optional extra columns.
+     *
+     * While the cols parameter has to match the count of headers defined,
+     * the extraCols parameters can be of any length (or null).
+     * Its values, if present, will simply be appended to the end of the list.
+     *
+     * @param cols A list of default columns (matching the headers)
+     * @param extraCols An optional list of appended columns that don't match any header
+     *
+     * @throws IllegalArgumentException if {@code cols.size() != numColumns}
+     * @throws NullPointerException if cols is null
+     */
+    protected void writeRow(List<String> cols, List<String> extraCols) {
         checkLength(cols);
-        csvWriter.writeNext(cleanRow(cols));
+        List<String> fullRow = extraCols == null ? cols : ListUtils.union(cols, extraCols);
+        csvWriter.writeNext(cleanRow(fullRow));
     }
 
     private void checkLength(List<String> cols) {


### PR DESCRIPTION
This PR adds a few extra fields to the proposal export. Most notably, it now also exports content. Since different contests have different sections, the amount of columns for the section data is flexible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/113)
<!-- Reviewable:end -->
