### PR TITLE
[COLAB-2848] Stop event propagation to prevent modal from closing

### DIFF
--- a/view/src/main/resources/static/js/proposals/proposals.js
+++ b/view/src/main/resources/static/js/proposals/proposals.js
@@ -96,7 +96,7 @@ $(function() {
     });
 
     $recipientInput.bind("autocompleteselect", "select", function(event) {
-
+        event.stopPropagation();
     });
 });
 


### PR DESCRIPTION
JQuery's UI autocomplete widget finds a list of matching members to
invite to a team. When selecting one, the invite modal closes, but
the invitation isn't sent. Prevent bubbling of the click event keeps the modal open after selection.

This fixes COLAB-2848.

PS: I opened a pull request against master by mistake, sorry about that.