### PR TITLE
Fix start up warnings

### DIFF
--- a/scripts/run/startServices.sh
+++ b/scripts/run/startServices.sh
@@ -27,7 +27,7 @@ function startService {
         rm ${OUT_FILE} > /dev/null 2>&1
         exec java -Xmx1G -Xms256M -XX:-OmitStackTraceInFastThrow \
          -jar ${service}-1.0-SNAPSHOT.jar > ${OUT_FILE} & echo $! > ${PID_FILE}
-        cd ${SAVED_DIR}
+        cd "${SAVED_DIR}"
     fi
 }
 
@@ -44,7 +44,7 @@ else
     done
 fi
 
-cd ${PREVIOUS_DIR}
+cd "${PREVIOUS_DIR}"
 
 echo "[INFO] Done."
 echo "#####################################################################################"

--- a/scripts/run/stopServices.sh
+++ b/scripts/run/stopServices.sh
@@ -30,7 +30,7 @@ else
     done
 fi
 
-cd ${PREVIOUS_DIR}
+cd "${PREVIOUS_DIR}"
 
 echo "[INFO] Done."
 echo "#####################################################################################"


### PR DESCRIPTION
Add quotation marks to shell commands to support file paths which contain spaces

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/150)
<!-- Reviewable:end -->
