### PR TITLE
[COLAB-2920]: reversed default sort order of contests by weight

### DIFF
--- a/view/src/main/java/org/xcolab/view/pages/proposals/utils/ContestsColumn.java
+++ b/view/src/main/java/org/xcolab/view/pages/proposals/utils/ContestsColumn.java
@@ -41,7 +41,7 @@ public enum ContestsColumn {
         return 0;
     }),
 
-    DEFAULT(Comparator.comparingInt(AbstractContest::getWeight));
+    DEFAULT(Comparator.comparingInt(Contest::getWeight).reversed());
     
     private final Comparator<Contest> columnComparator;
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cci-mit/xcolab/169)
<!-- Reviewable:end -->
