### PR TITLE
Add default case for switch statement

### DIFF
--- a/microservices/services/moderation-service/src/main/java/org/xcolab/service/moderation/domain/report/ReportDaoImpl.java
+++ b/microservices/services/moderation-service/src/main/java/org/xcolab/service/moderation/domain/report/ReportDaoImpl.java
@@ -62,6 +62,11 @@ public class ReportDaoImpl implements ReportDao {
                     query.addOrderBy(sortColumn.isAscending()
                             ? REPORT.CREATED_AT.asc() : REPORT.CREATED_AT.desc());
                     break;
+                //missing default case
+                default:
+                    // add default case
+                    break;
+
             }
         }
         query.addLimit(paginationHelper.getStartRecord(), paginationHelper.getCount());
@@ -123,6 +128,11 @@ public class ReportDaoImpl implements ReportDao {
                     query.addOrderBy(sortColumn.isAscending()
                             ? count.asc() : count.desc());
                     break;
+                //missing default case
+                default:
+                    // add default case
+                    break;
+
             }
         }
         query.addLimit(paginationHelper.getStartRecord(), paginationHelper.getCount());


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html