### PR TITLE
Add default case for switch statements

### DIFF
--- a/microservices/clients/contest-client/src/main/java/org/xcolab/client/contest/proposals/enums/points/PointsDistributionUtil.java
+++ b/microservices/clients/contest-client/src/main/java/org/xcolab/client/contest/proposals/enums/points/PointsDistributionUtil.java
@@ -81,6 +81,11 @@ public class PointsDistributionUtil {
                 return distributeEquallyAmongProposals(proposalIds);
             case SECTION_DEFINED:
                 return distributeSectionDefinedAmongProposals(parentProposals, pointType, proposalIds);
+            //missing default case
+            default:
+            // add default case
+                break;
+
         }
         return Collections.emptyList();
     }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html