### PR TITLE
Add default case for switch statements

### DIFF
--- a/microservices/services/comment-service/src/main/java/org/xcolab/service/comment/domain/thread/ThreadDaoImpl.java
+++ b/microservices/services/comment-service/src/main/java/org/xcolab/service/comment/domain/thread/ThreadDaoImpl.java
@@ -100,6 +100,11 @@ public class ThreadDaoImpl implements ThreadDao {
                     query.addOrderBy(sortColumn.isAscending()
                             ? THREAD.CREATED_AT.asc() : THREAD.CREATED_AT.desc());
                     break;
+                //missing default case
+                default:
+                    // add default case
+                    break;
+
             }
         }
         query.addConditions(THREAD.DELETED_AT.isNull());


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html