### PR TITLE
Add default case for switch statements

### DIFF
--- a/util/entity-utils/src/main/java/org/xcolab/entity/utils/notifications/contest/ContestVoteQuestionNotification.java
+++ b/util/entity-utils/src/main/java/org/xcolab/entity/utils/notifications/contest/ContestVoteQuestionNotification.java
@@ -78,6 +78,12 @@ public class ContestVoteQuestionNotification extends ContestNotification {
                     }
                     supportedProposalsLinks.append("</span>");
                     return parseXmlNode(supportedProposalsLinks.toString());
+                 
+                //missing default case
+                default:
+                    // add default case
+                    break;
+
             }
             return null;
         }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html