### PR TITLE
Add default case for switch statements

### DIFF
--- a/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/proposal/enums/PointsDistributionUtil.java
+++ b/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/proposal/enums/PointsDistributionUtil.java
@@ -79,6 +79,10 @@ public class PointsDistributionUtil {
                 return distributeEquallyAmongProposals(proposalIds);
             case SECTION_DEFINED:
                 return distributeSectionDefinedAmongProposals(parentProposals, pointType, proposalIds);
+            //missing default case
+            default:
+            // add default case
+                break;
         }
         return Collections.emptyList();
     }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html