### PR TITLE
Add default case for switch statements

### DIFF
--- a/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/proposal/service/proposalreference/ProposalReferenceService.java
+++ b/microservices/services/contest-service/src/main/java/org/xcolab/service/contest/proposal/service/proposalreference/ProposalReferenceService.java
@@ -101,6 +101,11 @@ public class ProposalReferenceService {
                             .addAll(getProposalIdsFromLinksInText(attribute.getStringValue()));
                     break;
                 }
+                    
+               //missing default case
+               default:
+                    // add default case
+                   break;
             }
 
             for (long subProposalId : subProposalIds) {


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html