### PR TITLE
Add default case for switch statements

### DIFF
--- a/microservices/services/comment-service/src/main/java/org/xcolab/service/comment/domain/category/CategoryDaoImpl.java
+++ b/microservices/services/comment-service/src/main/java/org/xcolab/service/comment/domain/category/CategoryDaoImpl.java
@@ -43,6 +43,12 @@ public class CategoryDaoImpl implements CategoryDao {
                     query.addOrderBy(sortColumn.isAscending()
                             ? CATEGORY.CREATED_AT.asc() : CATEGORY.CREATED_AT.desc());
                     break;
+                    
+                //missing default case
+                default:
+                    // add default case
+                    break;
+
             }
         }
         query.addConditions(CATEGORY.DELETED_AT.isNull());


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html