### PR TITLE
Add default case for switch statements

### DIFF
--- a/microservices/services/comment-service/src/main/java/org/xcolab/service/comment/domain/comment/CommentDaoImpl.java
+++ b/microservices/services/comment-service/src/main/java/org/xcolab/service/comment/domain/comment/CommentDaoImpl.java
@@ -65,6 +65,11 @@ public class CommentDaoImpl implements CommentDao {
                     query.addOrderBy(sortColumn.isAscending()
                             ? COMMENT.CREATED_AT.asc() : COMMENT.CREATED_AT.desc());
                     break;
+                //missing default case
+                default:
+                    // add default case
+                    break;
+
             }
         }
         if (!includeDeleted) {


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html