### PR TITLE
Add default case for switch statements

### DIFF
--- a/util/entity-utils/src/main/java/org/xcolab/entity/utils/notifications/EmailTemplateWrapper.java
+++ b/util/entity-utils/src/main/java/org/xcolab/entity/utils/notifications/EmailTemplateWrapper.java
@@ -54,6 +54,10 @@ public class EmailTemplateWrapper {
                 return new TextNode(this.proposalName);
             case CONTEST_TITLE_PLACEHOLDER:
                 return new TextNode(this.contestName);
+            //missing default case
+            default:
+                // add default case
+                break;
         }
         return null;
     }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html