### PR TITLE
Add default case for switch statements

### DIFF
--- a/util/entity-utils/src/main/java/org/xcolab/entity/utils/notifications/proposal/ProposalVoteValidityConfirmation.java
+++ b/util/entity-utils/src/main/java/org/xcolab/entity/utils/notifications/proposal/ProposalVoteValidityConfirmation.java
@@ -79,6 +79,11 @@ public class ProposalVoteValidityConfirmation extends ProposalNotification {
             switch (tag.nodeName()) {
                 case CONFIRMATION_LINK_PLACEHOLDER:
                     return parseXmlNode(getConfirmationLink(tag.ownText()));
+                //missing default case
+                default:
+                    // add default case
+                    break;
+
             }
             return null;
         }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html