### PR TITLE
Add default case for switch statements

### DIFF
--- a/util/xcolab-utils/src/main/java/org/xcolab/util/http/caching/provider/ehcache3/statistics/CacheStatisticProvider.java
+++ b/util/xcolab-utils/src/main/java/org/xcolab/util/http/caching/provider/ehcache3/statistics/CacheStatisticProvider.java
@@ -55,6 +55,11 @@ public class CacheStatisticProvider {
                 getMissMeter(cacheName, cachedClass).mark();
                 getMissMeter(cacheName, null).mark();
                 break;
+             //missing default case
+            default:
+            // add default case
+                break;
+
         }
     }
 


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html