### PR TITLE
Add default case for switch statements

### DIFF
--- a/view/src/main/java/org/xcolab/view/util/validation/CompareStringsValidator.java
+++ b/view/src/main/java/org/xcolab/view/util/validation/CompareStringsValidator.java
@@ -47,6 +47,11 @@ public class CompareStringsValidator implements ConstraintValidator<CompareStrin
             case EQUAL_IGNORE_CASE:
                 isValid = StringUtils.equalsIgnoreCase(s1, s2);
                 break;
+            //missing default case
+            default:
+                // add default case
+                break;
+
         }
 
         if (!isValid) {


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html